### PR TITLE
fixes to Vox clothing and storage webbing

### DIFF
--- a/code/modules/clothing/under/xenos/vox.dm
+++ b/code/modules/clothing/under/xenos/vox.dm
@@ -1,8 +1,6 @@
 /obj/item/clothing/under/vox
 	has_sensor = 0
 	species_restricted = list(SPECIES_VOX)
-	valid_accessory_slots = "vox"
-	restricted_accessory_slots = "vox"
 	phoronproof = 1
 
 /obj/item/clothing/under/vox/vox_casual
@@ -23,7 +21,7 @@
 	name = "alien mesh"
 	desc = "An alien mesh. Seems to be made up mostly of pockets and writhing flesh."
 	icon_state = "webbing-vox"
-	slot = "vox"
+	slot = ACCESSORY_SLOT_UTILITY
 
 	slots = 3
 


### PR DESCRIPTION
The clothing for vox had not been updated when the changes to accessory's and how they attached were made.

This has updated vox under clothing, and the vox storage harness to make use of the standard layout

Specificity it removed the unique "vox" accessory point, which was not defined, therefor didn't work (so you couldn't equip the vox webbing to vox clothing, even).
And made them use the same valid/restricted points as their parents.

**This does however mean that vox under suits can equip things as per a standard jumpsuit could be expected to, and has no special rules associated anymore for been..well..vox
Same can be said for the webbing, it can be equipped to anywhere as per a normal webbing rules, and has no specific restrictions anymore simply for been vox-made.**

_Honestly this is more just a potentially quick fix for our vox players, as finding out the exact how/why "vox" wasnt working as an attachment point..the only thing i can think of is it was skipped when some other attachment things changed, and this is the best way i can think of to fix it without diving in to code or making a unique attachment point in the defines/clothing.dm..which uses bits. and i'd rather not make unique points in a fairly limited table already just for..a few pieces of snowflake clothing that maybe only one or two people use._