### PR TITLE
NSFW to BSG again, and lick-wound self lick.

### DIFF
--- a/code/game/objects/items/gunbox_yw.dm
+++ b/code/game/objects/items/gunbox_yw.dm
@@ -26,10 +26,10 @@
 
 /obj/item/gunbox/blueshield/secondary/attack_self(mob/living/user)
 	var/list/options = list()
-//	options["NSFW Variable Pistol(Microbattery)"] = list(/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos) It's broken, and I can't fix it because the snowflake keeps metastasizing.
+	options["NSFW Variable Pistol(Microbattery)"] = list(/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos)
 	options["E-Gun (Weapon Cell)"] = list(/obj/item/weapon/gun/energy/gun, /obj/item/weapon/cell/device/weapon, /obj/item/weapon/cell/device/weapon)
 	options["Consul Revolver (.44)"] = list(/obj/item/weapon/gun/projectile/revolver/consul, /obj/item/ammo_magazine/s44, /obj/item/ammo_magazine/s44, /obj/item/ammo_magazine/s44/rubber)
-	var/choice = input(user,"Would you prefer an e-gun or a revolver?") as null|anything in options
+	var/choice = input(user,"Would you prefer an NSFW, e-gun or a revolver?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]
 		for(var/new_type in things_to_spawn) // Spawn all the things, the gun and the ammo.

--- a/code/modules/mob/living/carbon/lick_wounds.dm
+++ b/code/modules/mob/living/carbon/lick_wounds.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M) //YWedit, origionally, living/carbon/M in living_mobs(1), However, living_mobs does not include src as possible target.
+/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M) //YWedit, originally, living/carbon/M in living_mobs(1), However, living_mobs does not include src as possible target.
 	set name = "Lick Wounds"
 	set category = "Abilities"
 	set desc = "Disinfect and heal small wounds with your saliva."

--- a/code/modules/mob/living/carbon/lick_wounds.dm
+++ b/code/modules/mob/living/carbon/lick_wounds.dm
@@ -1,10 +1,14 @@
-/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M in living_mobs(1))
+/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M) //YWedit, origionally, living/carbon/M in living_mobs(1), However, living_mobs does not include src as possible target.
 	set name = "Lick Wounds"
 	set category = "Abilities"
 	set desc = "Disinfect and heal small wounds with your saliva."
 
 	if(nutrition < 50)
 		to_chat(src, "<span class='warning'>You need more energy to produce antiseptic enzymes. Eat something and try again.</span>")
+		return
+	//YW edit. Added the distance check to here. this allows the ability to lick ones own wounds. although this also means that all living/carbon/M appear on the list if used.
+	if (get_dist(src,M) >= 2)
+		src << "<span class='warning'>You need to be closer to do that.</span>"
 		return
 
 	if ( ! (istype(src, /mob/living/carbon/human) || \
@@ -68,7 +72,7 @@
 					return 
 
 				else
-					visible_message("<span class='notice'>\The [src] [pick("slathers \a [W.desc] on [M]'s [affecting.name] with their spit.", 
+					visible_message("<span class='notice'>\The [src] [pick("slathers \a [W.desc] on [M]'s [affecting.name] with their spit.",
 																			   "drags their tongue across \a [W.desc] on [M]'s [affecting.name].",
 																			   "drips saliva onto \a [W.desc] on [M]'s [affecting.name].",
 																			   "uses their tongue to disinfect \a [W.desc] on [M]'s [affecting.name].",


### PR DESCRIPTION
2 items in this one!

- First is to re-add the NSFW weapon to the BSG secondary armament, given it used to be a thing before the weapon got broken, now its fixed again... so.. 
- Second is to add the ability to use the new lick-wound ability on yourself too
_i wont lie, the way i've done this is probably a little hacky. the end result though, is that you can use the same ability to lick yourself and others around you, but most carbon/human mobs on screen will appear as 'lickable' in the target list if its used instead of the right click menu. and will tell you to get closer instead of just hiding them from the list. there's probably a way to do this better, but im unsure how after searching for a good portion of today._