### PR TITLE
Balance + New Traits Patch

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -25,7 +25,7 @@
 /datum/trait/endurance_low
 	name = "Low Endurance"
 	desc = "Reduces your maximum total hitpoints to 75."
-	cost = -2
+	cost = -4
 	var_changes = list("total_health" = 75)
 
 	apply(var/datum/species/S,var/mob/living/carbon/human/H)
@@ -35,7 +35,7 @@
 /datum/trait/endurance_very_low
 	name = "Extremely Low Endurance"
 	desc = "Reduces your maximum total hitpoints to 50."
-	cost = -3 //Teshari HP. This makes the person a lot more suseptable to getting stunned, killed, etc.
+	cost = -5 //Teshari HP. This makes the person a lot more suseptable to getting stunned, killed, etc.
 	var_changes = list("total_health" = 50)
 
 	apply(var/datum/species/S,var/mob/living/carbon/human/H)
@@ -44,56 +44,62 @@
 
 /datum/trait/minor_brute_weak
 	name = "Minor Brute Weakness"
-	desc = "Increases damage from brute damage sources by 15%"
+	desc = "Increases damage from brute damage sources by 10%"
 	cost = -1
-	var_changes = list("brute_mod" = 1.15)
+	var_changes = list("brute_mod" = 1.1)
 
 /datum/trait/brute_weak
 	name = "Brute Weakness"
-	desc = "Increases damage from brute damage sources by 25%"
+	desc = "Increases damage from brute damage sources by 20%"
 	cost = -2
-	var_changes = list("brute_mod" = 1.25)
+	var_changes = list("brute_mod" = 1.2)
 
 /datum/trait/brute_weak_plus
 	name = "Major Brute Weakness"
 	desc = "Increases damage from brute damage sources by 50%"
-	cost = -3
+	cost = -4
 	var_changes = list("brute_mod" = 1.5)
 
 /datum/trait/minor_burn_weak
 	name = "Minor Burn Weakness"
-	desc = "Increases damage from burn damage sources by 15%"
+	desc = "Increases damage from burn damage sources by 10%"
 	cost = -1
-	var_changes = list("burn_mod" = 1.15)
+	var_changes = list("burn_mod" = 1.1)
 
 /datum/trait/burn_weak
 	name = "Burn Weakness"
-	desc = "Increases damage from burn damage sources by 25%"
+	desc = "Increases damage from burn damage sources by 20%"
 	cost = -2
-	var_changes = list("burn_mod" = 1.25)
+	var_changes = list("burn_mod" = 1.2)
 
 /datum/trait/burn_weak_plus
 	name = "Major Burn Weakness"
-	desc = "Increases damage from burn damage sources by 50%"
-	cost = -3
-	var_changes = list("burn_mod" = 1.5)
+	desc = "Increases damage from burn damage sources by 40%"
+	cost = -4
+	var_changes = list("burn_mod" = 1.4)
 
 /datum/trait/conductive
 	name = "Conductive"
-	desc = "Increases your susceptibility to electric shocks by 50%"
+	desc = "Increases your susceptibility to electric shocks by 25%"
 	cost = -2
-	var_changes = list("siemens_coefficient" = 1.5) //This makes you a lot weaker to tasers.
+	var_changes = list("siemens_coefficient" = 1.25) //This makes you a lot weaker to tasers.
 
 /datum/trait/conductive_plus
 	name = "Major Conductive"
+	desc = "Increases your susceptibility to electric shocks by 50%"
+	cost = -4
+	var_changes = list("siemens_coefficient" = 1.5) //This makes you significantly weaker to tasers.
+
+/datum/trait/conductive_extreme
+	name = "Extremely Conductive"
 	desc = "Increases your susceptibility to electric shocks by 100%"
-	cost = -3
+	cost = -6
 	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
 /datum/trait/hollow
 	name = "Hollow Bones/Aluminum Alloy"
 	desc = "Your bones and robot limbs are much easier to break."
-	cost = -2 //I feel like this should be higher, but let's see where it goes
+	cost = -3 // increased due to medical intervention needed.
 
 /datum/trait/hollow/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -110,7 +116,7 @@
 /datum/trait/colorblind/mono
 	name = "Colorblindness (Monochromancy)"
 	desc = "You simply can't see colors at all, period. You are 100% colorblind."
-	cost = -3
+	cost = -4
 
 /datum/trait/colorblind/mono/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -119,7 +125,7 @@
 /datum/trait/colorblind/para_vulp
 	name = "Colorblindness (Para Vulp)"
 	desc = "You have a severe issue with green colors and have difficulty recognizing them from red colors."
-	cost = -2
+	cost = -3
 
 /datum/trait/colorblind/para_vulp/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -128,7 +134,7 @@
 /datum/trait/colorblind/para_taj
 	name = "Colorblindness (Para Taj)"
 	desc = "You have a minor issue with blue colors and have difficulty recognizing them from red colors."
-	cost = -1
+	cost = -3
 
 /datum/trait/colorblind/para_taj/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -46,7 +46,7 @@
 		),
 	autohiss_exempt = list("Sinta'unathi"))
 
-	excludes = list(/datum/trait/autohiss_tajaran)
+	excludes = list(/datum/trait/autohiss_tajaran, /datum/traits/autohiss_vassilian)
 
 /datum/trait/autohiss_tajaran
 	name = "Autohiss (Tajaran)"
@@ -57,7 +57,24 @@
 			"r" = list("rr", "rrr", "rrrr")
 		),
 	autohiss_exempt = list("Siik"))
-	excludes = list(/datum/trait/autohiss_unathi)
+	excludes = list(/datum/trait/autohiss_unathi, /datum/traits/autohiss_vassilian)
+
+// YW addition
+/datum/traits/autohiss_vassilian
+	name = "Autohiss (Vassilian)"
+	desc = "You buzz your S's, F's, Th's, and R's."
+	cost = 0
+	var_changes = list(
+	autohiss_basic_map = list(
+        "s" = list("sz", "z", "zz"),
+        "f" = list("zk")
+		),
+	autohiss_extra_map = list(
+		"th" = list("zk", "szk"),
+        "r" = list("rk")
+	),
+	autohiss_exempt = list("Vespinae"))
+	excludes = list(/datum/trait/autohiss_tajaran, /datum/trait/autohiss_unathi)
 
 /datum/trait/bloodsucker
 	name = "Bloodsucker"
@@ -83,7 +100,7 @@
 /datum/trait/hard_vore
 	name = "Brutal Predation"
 	desc = "Allows you to tear off limbs & tear out internal organs."
-	cost = 0 //I would make this cost a point, since it has some in game value, but there are easier, less damaging ways to perform the same functions.
+	cost = 0
 
 /datum/trait/hard_vore/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -94,6 +111,8 @@
 	desc = "Allows you to dispose of some garbage on the go instead of having to look for a bin or littering like an animal."
 	cost = 0
 	var_changes = list("trashcan" = 1)
+
+// TODO: trait for eating wearable objects and tools.
 
 /datum/trait/trashcan/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -1,13 +1,13 @@
 /datum/trait/speed_fast
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
-	cost = 3
+	cost = 2
 	var_changes = list("slowdown" = -0.5)
 
 /datum/trait/speed_fast_plus
 	name = "Major Haste"
 	desc = "Allows you to move MUCH faster on average than baseline."
-	cost = 5
+	cost = 4
 	var_changes = list("slowdown" = -1.0)
 
 /datum/trait/hardy
@@ -42,29 +42,45 @@
 		..(S,H)
 		H.setMaxHealth(S.total_health)
 
+/datum/trait/endurance_extremely_high
+	name = "Extremely High Endurance"
+	desc = "Increases your maximum total hitpoints to 175"
+	cost = 5
+	var_changes = list("total_health" = 175)
+
+	apply(var/datum/species/S,var/mob/living/carbon/human/H)
+		..(S,H)
+		H.setMaxHealth(S.total_health)
+
 /datum/trait/nonconductive
 	name = "Non-Conductive"
-	desc = "Decreases your susceptibility to electric shocks by a 25% amount."
+	desc = "Decreases your susceptibility to electric shocks by 25%."
 	cost = 2 //This effects tasers!
 	var_changes = list("siemens_coefficient" = 0.75)
 
 /datum/trait/nonconductive_plus
 	name = "Major Non-Conductive"
-	desc = "Decreases your susceptibility to electric shocks by a 50% amount."
+	desc = "Decreases your susceptibility to electric shocks by 50%."
 	cost = 3 //Let us not forget this effects tasers!
 	var_changes = list("siemens_coefficient" = 0.5)
+
+/datum/trait/nonconductive_robust
+	name = "Robustly Non-Conductive"
+	desc = "Decreases your susceptibility to electric shocks by 75%."
+	cost = 5 //Let us not forget this effects tasers!
+	var_changes = list("siemens_coefficient" = 0.25)
 
 /datum/trait/darksight
 	name = "Darksight"
 	desc = "Allows you to see a short distance in the dark."
 	cost = 1
-	var_changes = list("darksight" = 3, "flash_mod" = 2.0)
+	var_changes = list("darksight" = 3, "flash_mod" = 1.5)
 
 /datum/trait/darksight_plus
 	name = "Darksight (Major)"
-	desc = "Allows you to see in the dark for the whole screen."
+	desc = "Allows you to see in the dark for almost the whole screen."
 	cost = 2
-	var_changes = list("darksight" = 7, "flash_mod" = 3.0)
+	var_changes = list("darksight" = 6, "flash_mod" = 2.0)
 
 /datum/trait/melee_attack
 	name = "Sharp Melee"
@@ -80,45 +96,45 @@
 
 /datum/trait/minor_brute_resist
 	name = "Minor Brute Resist"
-	desc = "Adds 15% resistance to brute damage sources."
+	desc = "Adds 10% resistance to brute damage sources."
 	cost = 1
-	var_changes = list("brute_mod" = 0.85)
+	var_changes = list("brute_mod" = 0.9)
 
 /datum/trait/brute_resist
 	name = "Brute Resist"
-	desc = "Adds 25% resistance to brute damage sources."
+	desc = "Adds 20% resistance to brute damage sources."
 	cost = 2
-	var_changes = list("brute_mod" = 0.75)
+	var_changes = list("brute_mod" = 0.8)
 
 /datum/trait/brute_resist_plus
 	name = "Major Brute Resist"
-	desc = "Adds 50% resistance to brute damage sources."
+	desc = "Adds 40% resistance to brute damage sources."
 	cost = 3
-	var_changes = list("brute_mod" = 0.5)
+	var_changes = list("brute_mod" = 0.6)
 
 /datum/trait/minor_burn_resist
 	name = "Minor Burn Resist"
-	desc = "Adds 15% resistance to burn damage sources."
+	desc = "Adds 10% resistance to burn damage sources."
 	cost = 1
-	var_changes = list("burn_mod" = 0.85)
+	var_changes = list("burn_mod" = 0.9)
 
 /datum/trait/burn_resist
 	name = "Burn Resist"
-	desc = "Adds 25% resistance to burn damage sources."
+	desc = "Adds 20% resistance to burn damage sources."
 	cost = 2
-	var_changes = list("burn_mod" = 0.75)
+	var_changes = list("burn_mod" = 0.8)
 
 /datum/trait/burn_resist_plus
 	name = "Major Burn Resist"
-	desc = "Adds 50% resistance to burn damage sources."
+	desc = "Adds 40% resistance to burn damage sources."
 	cost = 3
-	var_changes = list("burn_mod" = 0.5)
+	var_changes = list("burn_mod" = 0.6)
 
 /datum/trait/photoresistant
-	name = "Photoresistant"
-	desc = "Decreases stun duration from flashes and other light-based stuns and disabilities by 50%"
+	name = "Photoresistance"
+	desc = "Decreases stun duration from flashes and other light-based stuns and disabilities by 30%"
 	cost = 1
-	var_changes = list("flash_mod" = 0.5)
+	var_changes = list("flash_mod" = 0.7)
 
 /datum/trait/winged_flight
 	name = "Winged Flight"


### PR DESCRIPTION
Resolves a missing vocal speech letter-roll for spider-like and insect-like characters, located in traits
Updates trait points to address the fact that the maluses usually undershoot the boons by a wide margin in points.
Rebalanced the stats so that there isn't a complete 50% resistance to any particular damage, excepting electrocution.

