### PR TITLE
Adds Advanced and phasic medical scanners to Rnd 

### DIFF
--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -133,6 +133,26 @@
 	build_path = /obj/item/device/healthanalyzer/improved
 	sort_string = "MBBAG"
 
+//YAWN changes
+/datum/design/item/medical/advanced_analyzer
+	name = "advanced health analyzer"
+	desc = "A prototype version of the improved health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels, and neurological analysis suites"
+	id = "advanced_analyzer"
+	req_tech = list(TECH_MAGNET = 6, TECH_BIO = 7, TECH_PHORON = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1250, "gold" = 1750, "uranium" = 1000, "plastic" = 500)
+	build_path = /obj/item/device/healthanalyzer/advanced
+	sort_string = "MBBAH"
+
+/datum/design/item/medical/phasic_analyzer
+	name = "phasic health analyzer"
+	desc = "A prototype version of the advanced health analyzer, able to distinguish the location of more serious injuries as well as accurately determine radiation levels, and neurological analysis suites. This analyzer even picks up chemicals in the patient's stomach."
+	id = "phasic_analyzer"
+	req_tech = list(TECH_MAGNET = 7, TECH_BIO = 8, TECH_BLUESPACE = 6, TECH_PHORON = 5)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1500, "gold" = 2000, "uranium" = 1250, "diamond" = 750, "phoron" = 500, "plastic" = 1000, "osmium" = 500)
+	build_path = /obj/item/device/healthanalyzer/phasic
+	sort_string = "MBBAI"
+//End of YAWN changes
+
 /datum/design/item/implant
 	materials = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
 


### PR DESCRIPTION
The New!
Phasic heath scanner and Advanced health scanner can now be made at insane prices and techs meant for late in the round!

Why?
So people have a reason to bring osmium and other mats to rnd for use!
So medical can have a easier life as they can get fancy heath scanners... To make better malpractice