### PR TITLE
Command Secretary Access Changes

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -83,8 +83,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 5
 	economic_modifier = 7
 
-	access = list(access_heads, access_keycard_auth)
-	minimal_access = list(access_heads, access_keycard_auth)
+	access = list(access_heads, access_keycard_auth, access_RC_announce, access_medical, access_security) //YAWN EDIT
+	minimal_access = list(access_heads, access_keycard_auth)//YAWN EDIT
 
 	outfit_type = /decl/hierarchy/outfit/job/secretary
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -84,7 +84,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_modifier = 7
 
 	access = list(access_heads, access_keycard_auth, access_RC_announce, access_medical, access_security) //YAWN EDIT
-	minimal_access = list(access_heads, access_keycard_auth)//YAWN EDIT
+	minimal_access = list(access_heads, access_keycard_auth, access_RC_announce, access_medical, access_security)//YAWN EDIT
 
 	outfit_type = /decl/hierarchy/outfit/job/secretary
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -83,8 +83,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 5
 	economic_modifier = 7
 
-	access = list(access_heads, access_keycard_auth, access_RC_announce, access_medical, access_security) //YAWN EDIT
-	minimal_access = list(access_heads, access_keycard_auth, access_RC_announce, access_medical, access_security)//YAWN EDIT
+	access = list(access_heads, access_keycard_auth, access_RC_announce) //YAWN EDIT
+	minimal_access = list(access_heads, access_keycard_auth, access_RC_announce)//YAWN EDIT
 
 	outfit_type = /decl/hierarchy/outfit/job/secretary
 


### PR DESCRIPTION
This PR gives the Command Secretary the Request Console Announcement access. This allows them to help facilitate communication between the command staff and the crew when the command staff are too busy being command staff to head to a console for an annnouncement