### PR TITLE
Adds a new body bag for more/easyer body storge

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -42,6 +42,26 @@
 	storage_capacity = (MOB_MEDIUM * 2) - 1
 	var/contains_body = 0
 
+//Yawn add
+/obj/item/bodybag/large
+	name = "mass grave body bag"
+	desc = "A large folded bag designed for the storage and transportation of cadavers."
+	icon = 'icons/obj/bodybag.dmi'
+	icon_state = "bodybag_folded"
+	w_class = ITEMSIZE_LARGE
+
+	attack_self(mob/user)
+		var/obj/structure/closet/body_bag/large/R = new /obj/structure/closet/body_bag/large(user.loc)
+		R.add_fingerprint(user)
+		qdel(src)
+
+/obj/structure/closet/body_bag/large
+	name = "mass grave body bag"
+	desc = "A massive body bag that holds as much as it does do to bluespace lining on its zipper. Shockingly compact for its storage."
+	storage_capacity = (MOB_MEDIUM * 12) - 1 //Holds 12 bodys
+	item_path = /obj/item/bodybag/large
+//End of Yawn add
+
 /obj/structure/closet/body_bag/attackby(var/obj/item/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/pen))
 		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -90,6 +90,14 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 1000, "silver" = 1500, "gold" = 2000, "uranium" = 1250, "diamond" = 750, "phoron" = 500, "plastic" = 1000, "osmium" = 500)
 	build_path = /obj/item/device/healthanalyzer/phasic
 	sort_string = "KBAAD"
+
+/datum/design/item/medical/large_bodybag
+	desc = "A massive body bag made with bluespace tech."
+	id = "large_bodybag"
+	req_tech = list( TECH_ENGINEERING = 3, TECH_BIO = 5, TECH_BLUESPACE = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 3500, "glass" = 500, "phoron" = 4000, "plastic" = 18000) //2 phoron and 9 plastic sheets.
+	build_path = /obj/item/bodybag/large
+	sort_string = "KCAAB" //To be under the roller bed
 //End of YAWN changes
 
 /datum/design/item/medical/advanced_roller


### PR DESCRIPTION
The "Mass Grave" Body bag is a **tested** body bag using the arts of bluespace, fine packing and plastic to make a bag that is able to store up to 12 bodies inside it.
Whom has a use for such a grand way to move corpse? 
Well one, people killing solar grubs around the station, 
Two Xenobio and its mass graves for monkeys and slimes alike 
And three, medical themselves with clones of people dyeing not taking more then one morgue slab.
It does cost phoron just like adv medical beds, and higher levels of bluespace for its truly amazing storage.