### PR TITLE
Fix and reversion to Virgo naming of blood temp

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -19,12 +19,12 @@
 	var_changes = list("metabolic_rate" = 1.4, "hunger_factor" = 0.4, "metabolism" = 0.012) // +40% rate and 8x hunger (Double Teshari)
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
 
-/datum/trait/cold_discomfort
-	name = "Hot-Preference"
+/datum/trait/hot_blood
+	name = "Hot-Blooded"
 	desc = "You are too hot at the standard 20C. 18C is more suitable. Rolling down your jumpsuit or being unclothed helps."
 	cost = 0
 	var_changes = list("heat_discomfort_level" = T0C+19)
-	excludes = list(/datum/trait/hot_discomfort, /datum/trait/cold_blood)
+	excludes = list(/datum/trait/cold_blooded, /datum/trait/extreme_cold_blood)
 
 // YW Addition
 /*
@@ -33,24 +33,24 @@
 	desc = "Your body requires near cryogenic temperatures to operate. Extremely intricate arrangements are needed for you to remain indoors. The outdoors is comfortable for you, however. WARNING: You will spawn in an atmosphere that is VERY hostile to you with no protective equipment!"
 	cost = 0
 	var_changes = list("heat_discomfort_level" = T0C)
-	excludes = list(/datum/trait/cold_discomfort,/datum/trait/hot_discomfort,/datum/trait/cold_blood)
+	excludes = list(/datum/trait/hot_blooded,/datum/trait/cold_blooded,/datum/trait/extreme_cold_blood)
 */
 // YW Addition End
 
-/datum/trait/hot_discomfort
-	name = "Cold-Preference"
+/datum/trait/cold_blood
+	name = "Cold-Blooded"
 	desc = "You are too cold at the standard 20C. 22C is more suitable. Wearing clothing that covers your legs and torso helps."
 	cost = 0
 	var_changes = list("cold_discomfort_level" = T0C+21)
-	excludes = list(/datum/trait/cold_discomfort, /datum/trait/cold_blood)
+	excludes = list(/datum/trait/hot_blooded, /datum/trait/cold_blood)
 
 // YW Addition
-/datum/trait/cold_blood
-	name = "Cold Blooded"
+/datum/trait/extreme_cold_blood
+	name = "Extremely Cold Blooded"
 	desc = "Your body relies on the outside temperature to keep warm. Wearing warm clothing such as jackets is commonplace for you."
 	cost = 0
 	var_changes = list("cold_discomfort_level" = T0C+24)
-	excludes = list(/datum/trait/hot_discomfort, /datum/trait/cold_discomfort)
+	excludes = list(/datum/trait/hot_blooded, /datum/trait/cold_blooded)
 // YW Addition End
 
 /datum/trait/autohiss_unathi

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -24,7 +24,7 @@
 	desc = "You are too hot at the standard 20C. 18C is more suitable. Rolling down your jumpsuit or being unclothed helps."
 	cost = 0
 	var_changes = list("heat_discomfort_level" = T0C+19)
-	excludes = list(/datum/trait/cold_blooded, /datum/trait/extreme_cold_blood)
+	excludes = list(/datum/trait/cold_blood, /datum/trait/extreme_cold_blood)
 
 // YW Addition
 /*
@@ -33,7 +33,7 @@
 	desc = "Your body requires near cryogenic temperatures to operate. Extremely intricate arrangements are needed for you to remain indoors. The outdoors is comfortable for you, however. WARNING: You will spawn in an atmosphere that is VERY hostile to you with no protective equipment!"
 	cost = 0
 	var_changes = list("heat_discomfort_level" = T0C)
-	excludes = list(/datum/trait/hot_blooded,/datum/trait/cold_blooded,/datum/trait/extreme_cold_blood)
+	excludes = list(/datum/trait/hot_blood,/datum/trait/cold_blood,/datum/trait/extreme_cold_blood)
 */
 // YW Addition End
 
@@ -42,7 +42,7 @@
 	desc = "You are too cold at the standard 20C. 22C is more suitable. Wearing clothing that covers your legs and torso helps."
 	cost = 0
 	var_changes = list("cold_discomfort_level" = T0C+21)
-	excludes = list(/datum/trait/hot_blooded, /datum/trait/cold_blood)
+	excludes = list(/datum/trait/hot_blood, /datum/trait/cold_blood)
 
 // YW Addition
 /datum/trait/extreme_cold_blood
@@ -50,7 +50,7 @@
 	desc = "Your body relies on the outside temperature to keep warm. Wearing warm clothing such as jackets is commonplace for you."
 	cost = 0
 	var_changes = list("cold_discomfort_level" = T0C+24)
-	excludes = list(/datum/trait/hot_blooded, /datum/trait/cold_blooded)
+	excludes = list(/datum/trait/hot_blood, /datum/trait/cold_blood)
 // YW Addition End
 
 /datum/trait/autohiss_unathi


### PR DESCRIPTION
Your descriptions are backwards
https://github.com/Yawn-Wider/YWPolarisVore/blob/2f778a08d4bac1fa9cff00a919bb7e171edea6d8/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm#L22

This does not work that way
![image](https://user-images.githubusercontent.com/15962836/72418085-64144380-3737-11ea-9710-2c455f1b27cc.png)


This PR, should you choose to accept, reverts it back to the Virgo method of just calling it cold blooded and hot blooded, also renaming your additional, more severe trait to `extremely cold-blooded`.

If you decline, that's alright. Just swap them saying hot and cold.