### PR TITLE
Stacker Machine Runtime fix

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -131,6 +131,7 @@
 			stack_storage[sheet] -= stack_amt
 			S.update_icon()
 
-	console.updateUsrDialog()
+	if(console)
+		console.updateUsrDialog()
 	return
 


### PR DESCRIPTION
runtime machine bad
```
[2020-01-25T20:10:51] Runtime in machine_stacking.dm,134: Cannot execute null.updateUsrDialog().
   proc name: process (/obj/machinery/mineral/stacking_machine/process)
```
e: will port up