### PR TITLE
Batons harmbaton on grab/harm instead of disarm/harm

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -178,7 +178,7 @@
 		var/mob/living/carbon/human/H = target
 		affecting = H.get_organ(hit_zone)
 
-	if(user.a_intent == I_HURT || user.a_intent == I_DISARM)
+	if( user.a_intent == I_GRAB || user.a_intent == I_HURT ) // YW Edit
 		. = ..()
 		//whacking someone causes a much poorer electrical contact than deliberately prodding them.
 		agony *= 0.5

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -178,7 +178,7 @@
 		var/mob/living/carbon/human/H = target
 		affecting = H.get_organ(hit_zone)
 
-	if( user.a_intent == I_GRAB || user.a_intent == I_HURT ) // YW Edit
+	if(user.a_intent == I_GRAB || user.a_intent == I_HURT) // YW Edit
 		. = ..()
 		//whacking someone causes a much poorer electrical contact than deliberately prodding them.
 		agony *= 0.5


### PR DESCRIPTION
disarm usually used to enable guns to fire, why also make it harmies?