### PR TITLE
changes engineering zaddat suit(engineering type) to give 100% rad protection

### DIFF
--- a/code/modules/clothing/spacesuits/void/zaddat.dm
+++ b/code/modules/clothing/spacesuits/void/zaddat.dm
@@ -46,11 +46,13 @@
 			desc = "This rugged Shroud was created by the Xozi Engineering Guild."
 			icon_state = "zaddat_engie"
 			item_state = "zaddat_engie"
+			armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 			if(helmet)
 				helmet.name = "\improper Engineer's Guild Shroud helmet"
 				helmet.desc = "A Shroud helmet designed for good visibility in low-light environments."
 				helmet.icon_state = "zaddat_engie"
 				helmet.item_state = "zaddat_engie"
+				helmet.armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 		if("Spacer")
 			name = "\improper Spacer's Guild Shroud"
 			base_name = "\improper Spacer's Guild Shroud"


### PR DESCRIPTION
This basically makes so the engineering zaddat shroud gives 100% rad protection instead of 70% from the basic one, DIND'T TEST YET, but should be working, i got no time to test now but if anyone sees as it should work from looking at code, feel free to merge