### PR TITLE
[FIX] Window Title & Lobby Backdrop

### DIFF
--- a/code/modules/mob/new_player/login_vr.dm
+++ b/code/modules/mob/new_player/login_vr.dm
@@ -1,2 +1,2 @@
 /obj/effect/lobby_image
-	name = "VORE Station"
+	name = "Yawn Wider Station" // YW EDIT

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1825,7 +1825,7 @@ window "mainwindow"
 		right-click = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		on-size = ""
-		title = "VOREStation"
+		title = "Yawn Wider Station" //YW EDIT
 		titlebar = true
 		statusbar = true
 		can-close = true


### PR DESCRIPTION
Fixes the name for the window and the name of the lobby backdrop image (as displayed in the lower left corner) when hovering the mouse over it.

Basically all there is to say. Enjoy! Or don't, I guess.