### PR TITLE
[FIX] AR-M Glasses Unselectable

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes_yw.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes_yw.dm
@@ -9,7 +9,7 @@
 	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician")
 
 /datum/gear/eyes/arglasses/med
-	display_name = "AR-M glasses (Med, S&R)"
+	display_name = "AR-M glasses (Med, SAR)"
 	path = /obj/item/clothing/glasses/omnihud/med
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
 


### PR DESCRIPTION
Turns out you're not allowed to use & signs in loadout item names. This made the AR-M glasses impossible to pick as they'd just throw a runtime and stay unselected. Oops.

This PR fixes that by swapping S&R for S*A*R in the loadout name. Tested locally and actually works.