### PR TITLE
removes "return" that causes rest of code not work

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1525,7 +1525,6 @@
 	else
 		shock_stage = min(shock_stage, 160)
 		shock_stage = max(shock_stage-1, 0)
-		return
 
 	if(stat)
 		return 0


### PR DESCRIPTION
This return was actually returning before the rest of code would run, causing it to not work the shock_stage debuffs, making xenochimera and vasilissan and even diona codes to not work properly, or anything else that uses shock_stage, if the return is needed it can be added after the rest of the code