### PR TITLE
Ports Inactivity SS from Bay (Polaris Mirror)

### DIFF
--- a/code/controllers/subsystems/inactivity.dm
+++ b/code/controllers/subsystems/inactivity.dm
@@ -1,42 +1,58 @@
 SUBSYSTEM_DEF(inactivity)
-	name = "AFK Kick"
-	wait = 600
-	flags = SS_BACKGROUND | SS_NO_TICK_CHECK
+	name = "Inactivity"
+	wait = 1 MINUTE
+	flags = SS_NO_INIT | SS_BACKGROUND
+	var/tmp/list/client_list
+	var/number_kicked = 0
 
-/datum/controller/subsystem/inactivity/fire()
-	if(config.kick_inactive)
-		for(var/i in GLOB.clients)
-			var/client/C = i
-			if(C.is_afk(config.kick_inactive MINUTES) && !C.holder) // VOREStation Edit - Allow admins to idle
-				to_chat(C,"<span class='warning'>You have been inactive for more than [config.kick_inactive] minute\s and have been disconnected.</span>")
-				var/information
+/datum/controller/subsystem/inactivity/fire(resumed = FALSE)
+	if (!config.kick_inactive)
+		can_fire = FALSE
+		return
+	if (!resumed)
+		client_list = GLOB.clients.Copy()
 
-				if(C.mob)
-					if(ishuman(C.mob))
-						var/job
-						var/mob/living/carbon/human/H = C.mob
-						var/datum/data/record/R = find_general_record("name", H.real_name)
-						if(R)
-							job = R.fields["real_rank"]
-						if(!job && H.mind)
-							job = H.mind.assigned_role
-						if(!job && H.job)
-							job = H.job
-						if(job)
-							information = " while [job]."
+	while(client_list.len)
+		var/client/C = client_list[client_list.len]
+		client_list.len--
+		if(!C.holder && C.is_afk(config.kick_inactive MINUTES) && !isobserver(C.mob))
 
-					else if(issilicon(C.mob))
-						information = " while a silicon."
-						if(isAI(C.mob))
-							var/mob/living/silicon/ai/A = C.mob
-							empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(A.loc)
-							global_announcer.autosay("[A] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
-							A.clear_client()
-							information = " while an AI."
+			to_chat(C, "<span class='warning'>You have been inactive for more than [config.kick_inactive] minute\s and have been disconnected.</span>")
 
-				var/adminlinks
-				adminlinks = " (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[C.mob.x];Y=[C.mob.y];Z=[C.mob.z]'>JMP</a>|<A HREF='?_src_=holder;cryoplayer=\ref[C.mob]'>CRYO</a>)"
+			var/information
+			if(C.mob)
+				if(ishuman(C.mob))
+					var/job
+					var/mob/living/carbon/human/H = C.mob
+					var/datum/data/record/R = find_general_record("name", H.real_name)
+					if(R)
+						job = R.fields["real_rank"]
+					if(!job && H.mind)
+						job = H.mind.assigned_role
+					if(!job && H.job)
+						job = H.job
+					if(job)
+						information = " while [job]."
 
-				log_and_message_admins("being kicked for AFK[information][adminlinks]", C.mob)
+				else if(issilicon(C.mob))
+					information = " while a silicon."
+					if(isAI(C.mob))
+						var/mob/living/silicon/ai/A = C.mob
+						empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(A.loc)
+						global_announcer.autosay("[A] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
+						A.clear_client()
+						information = " while an AI."
 
-				qdel(C)
+			var/adminlinks
+			adminlinks = " (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[C.mob.x];Y=[C.mob.y];Z=[C.mob.z]'>JMP</a>|<A HREF='?_src_=holder;cryoplayer=\ref[C.mob]'>CRYO</a>)"
+
+			log_and_message_admins("being kicked for AFK[information][adminlinks]", C.mob)
+
+			qdel(C)
+			number_kicked++
+
+		if (MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/inactivity/stat_entry()
+	..("Kicked: [number_kicked]")


### PR DESCRIPTION
https://github.com/PolarisSS13/Polaris/pull/6805

Novacat commented 3 days ago
Remember that server-destroying timer bug that VORE keeps getting?

Turns out, it is related to the inactivity subsystem, that, due to having SS_BACKGROUND and SS_NO_TICK_CHECK flags, causes the master controller to break in a horrible way. One of the consequences of the master controller breaking is that the timer subsystem stops running.

I am relieved that this monster of a bug has finally been slain. Hopefully.