### PR TITLE
[SUPPLY] Blueshield Crates

### DIFF
--- a/code/datums/supplypacks/misc_yw.dm
+++ b/code/datums/supplypacks/misc_yw.dm
@@ -1,0 +1,26 @@
+/datum/supply_pack/misc/blueshieldgear
+	name = "Blueshield Special Equipment"
+	contains = list(
+			/obj/item/clothing/head/beret/blueshield = 1,
+			/obj/item/clothing/under/yw/blueshield = 1,
+			/obj/item/clothing/under/yw/blueshield2 = 1,
+			/obj/item/clothing/suit/armor/yw/blueshield = 1,
+			/obj/item/clothing/suit/armor/yw/blueshieldcoat = 1,
+			/obj/item/clothing/accessory/poncho/roles/cloak/blueshield = 1,
+			/obj/item/clothing/accessory/holster/leg = 1
+			)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Blueshield equipment"
+	access = access_heads
+	
+/datum/supply_pack/misc/blueshieldweapons
+	name = "Blueshield Weapon Kits"
+	contains = list(
+			/obj/item/gunbox/blueshield = 1,
+			/obj/item/gunbox/blueshield/secondary = 1
+			)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Blueshield armaments"
+	access = access_heads

--- a/code/datums/supplypacks/misc_yw.dm
+++ b/code/datums/supplypacks/misc_yw.dm
@@ -20,7 +20,7 @@
 			/obj/item/gunbox/blueshield = 1,
 			/obj/item/gunbox/blueshield/secondary = 1
 			)
-	cost = 50
+	cost = 100
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Blueshield armaments"
 	access = access_heads

--- a/code/datums/supplypacks/misc_yw.dm
+++ b/code/datums/supplypacks/misc_yw.dm
@@ -9,7 +9,7 @@
 			/obj/item/clothing/accessory/poncho/roles/cloak/blueshield = 1,
 			/obj/item/clothing/accessory/holster/leg = 1
 			)
-	cost = 50
+	cost = 80
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Blueshield equipment"
 	access = access_heads

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -401,6 +401,7 @@
 #include "code\datums\supplypacks\medical_vr.dm"
 #include "code\datums\supplypacks\misc.dm"
 #include "code\datums\supplypacks\misc_vr.dm"
+#include "code\datums\supplypacks\misc_yw.dm"
 #include "code\datums\supplypacks\munitions.dm"
 #include "code\datums\supplypacks\munitions_vr.dm"
 #include "code\datums\supplypacks\recreation.dm"


### PR DESCRIPTION
Adds a pair of locked crates with replacement Blueshield gear to cargo, under the Misc section. One contains some job-specific clothing, the other contains replacement weapon kits. Both require `access_heads` to unlock.

Allows for missing gear to be replaced or weapons to be changed without admin intervention, in the event of items being lost, destroyed, or taken off-shift.