### PR TITLE
[ACCESS] Blueshield Special Access

### DIFF
--- a/code/datums/supplypacks/misc_yw.dm
+++ b/code/datums/supplypacks/misc_yw.dm
@@ -12,7 +12,7 @@
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Blueshield equipment"
-	access = access_heads
+	access = access_blueshield
 	
 /datum/supply_pack/misc/blueshieldweapons
 	name = "Blueshield Weapon Kits"
@@ -23,4 +23,4 @@
 	cost = 100
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "Blueshield armaments"
-	access = access_heads
+	access = access_blueshield

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -298,15 +298,7 @@
 	region = ACCESS_REGION_SUPPLY
 
 // /var/const/free_access_id = 51
-
-//YW ADDITION START
-//allows blueshield to have special access independent of other access levels
-/var/const/access_blueshield = 52
-/datum/access/blueshield
-	id = access_blueshield
-	desc = "Blueshield Special Access"
-	region = ACCESS_REGION_COMMAND
-//YW ADDITION END
+// /var/const/free_access_id = 52
 
 /var/const/access_heads_vault = 53
 /datum/access/heads_vault

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -298,7 +298,15 @@
 	region = ACCESS_REGION_SUPPLY
 
 // /var/const/free_access_id = 51
-// /var/const/free_access_id= 52
+
+//YW ADDITION START
+//allows blueshield to have special access independent of other access levels
+/var/const/access_blueshield = 52
+/datum/access/blueshield
+	id = access_blueshield
+	desc = "Blueshield Special Access"
+	region = ACCESS_REGION_COMMAND
+//YW ADDITION END
 
 /var/const/access_heads_vault = 53
 /datum/access/heads_vault

--- a/code/game/jobs/access_datum_yw.dm
+++ b/code/game/jobs/access_datum_yw.dm
@@ -1,0 +1,5 @@
+/var/const/access_blueshield = 52
+/datum/access/blueshield
+	id = access_blueshield
+	desc = "Blueshield Special Access"
+	region = ACCESS_REGION_COMMAND

--- a/code/game/jobs/job/blueshield.dm
+++ b/code/game/jobs/job/blueshield.dm
@@ -17,7 +17,7 @@
 	access = list(access_security, access_sec_doors, access_brig,
 			            access_medical, access_eva, access_heads, access_teleporter,
 			            access_maint_tunnels, access_morgue,
-			            access_crematorium, access_research, access_hop, access_RC_announce, access_keycard_auth, access_gateway)
-	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_maint_tunnels, access_RC_announce, access_keycard_auth, access_heads)
+			            access_crematorium, access_research, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_blueshield)
+	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_maint_tunnels, access_RC_announce, access_keycard_auth, access_heads, access_blueshield)
 
 	outfit_type = /decl/hierarchy/outfit/job/blueshield

--- a/code/game/objects/structures/crates_lockers/closets/secure/closets_yw.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/closets_yw.dm
@@ -1,6 +1,6 @@
 /obj/structure/closet/secure_closet/blueshield
 	name = "blueshield's locker"
-	req_access = list(access_teleporter)
+	req_access = list(access_blueshield)
 	icon = 'icons/obj/closet_yw.dmi'
 	icon_state = "bssecure1"
 	icon_closed = "bssecure"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -711,6 +711,7 @@
 #include "code\game\jobs\access.dm"
 #include "code\game\jobs\access_datum.dm"
 #include "code\game\jobs\access_datum_vr.dm"
+#include "code\game\jobs\access_datum_yw.dm"
 #include "code\game\jobs\job_controller.dm"
 #include "code\game\jobs\jobs.dm"
 #include "code\game\jobs\whitelist.dm"


### PR DESCRIPTION
Adds a unique `access_blueshield` level (52) and adds it to the specific crates and the blueshield's locker, to reduce the ability of non-BSGs to get their hands on restricted equipment.

This will also make it easier to control where BSGs can go without giving the Heads all access to each others' departments.