### PR TITLE
Loyalty Implant Reimplementation

### DIFF
--- a/code/datums/supplypacks/security_yw.dm
+++ b/code/datums/supplypacks/security_yw.dm
@@ -1,0 +1,9 @@
+/datum/supply_pack/security/loyaltyimplants
+	name = "Loyalty Implant Lockbox"
+	contains = list(
+			/obj/item/weapon/storage/lockbox/loyalty
+			)
+	cost = 100
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Loyalty Implants Lockbox crate"
+	access = access_heads

--- a/code/game/jobs/job/blueshield.dm
+++ b/code/game/jobs/job/blueshield.dm
@@ -21,3 +21,8 @@
 	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_maint_tunnels, access_RC_announce, access_keycard_auth, access_heads)
 
 	outfit_type = /decl/hierarchy/outfit/job/blueshield
+
+/datum/job/blueshield/equip(var/mob/living/carbon/human/H)
+	. = ..()
+	if(.)
+		H.implant_loyalty(src)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -23,12 +23,13 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	outfit_type = /decl/hierarchy/outfit/job/captain
 	alt_titles = list("Site Manager", "Overseer")
 
-/*
+//YW UNCOMMENTINGSTART: REINSTATE LOYALTY IMPLANT
 /datum/job/captain/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(src)
-*/
+//YW UNCOMMENTING END
+
 /datum/job/captain/get_access()
 	return get_all_station_access().Copy()
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -153,9 +153,9 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/internal_affairs_agent
 
-/*
+//YW UNCOMMENTINGSTART: REINSTATE LOYALTY IMPLANT
 /datum/job/lawyer/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(H)
-*/
+//YW UNCOMMENTING END

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -25,6 +25,13 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
 	alt_titles = list("Security Commander", "Chief of Security")
 
+//YW ADDITION START: LOYALTY IMPLANT FOR HOS
+/datum/job/blueshield/equip(var/mob/living/carbon/human/H)
+	. = ..()
+	if(.)
+		H.implant_loyalty(src)
+//YW ADDITION END
+
 /datum/job/warden
 	title = "Warden"
 	flag = WARDEN

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -26,7 +26,7 @@
 	alt_titles = list("Security Commander", "Chief of Security")
 
 //YW ADDITION START: LOYALTY IMPLANT FOR HOS
-/datum/job/blueshield/equip(var/mob/living/carbon/human/H)
+/datum/job/hos/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(src)

--- a/code/game/jobs/job/special_vr.dm
+++ b/code/game/jobs/job/special_vr.dm
@@ -21,6 +21,13 @@
 	get_access()
 		return get_all_accesses().Copy()
 
+//YW UNCOMMENTINGSTART: INSTATE LOYALTY IMPLANT
+/datum/job/centcom_officer/equip(var/mob/living/carbon/human/H)
+	. = ..()
+	if(.)
+		H.implant_loyalty(src)
+//YW UNCOMMENTING END
+
 /*/datum/job/centcom_visitor //For Pleasure // You mean for admin abuse... -Ace
 	title = "CentCom Visitor"
 	department = "Civilian"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -412,6 +412,7 @@
 #include "code\datums\supplypacks\science.dm"
 #include "code\datums\supplypacks\security.dm"
 #include "code\datums\supplypacks\security_vr.dm"
+#include "code\datums\supplypacks\security_yw.dm"
 #include "code\datums\supplypacks\supply.dm"
 #include "code\datums\supplypacks\supply_vr.dm"
 #include "code\datums\supplypacks\supplypacks.dm"


### PR DESCRIPTION
Fixes #600 by:
* Adding a 100pt crate with a Loyalty Implant Lockbox to Supply/Cargo, requires `access_heads` for the main crate. Lockbox contains preloaded implanter and three additional implants.
* Adds roundstart/spawn loyalty implants for: CD, HoS, BSG, IAA, & CCO. Might be able to implement these a little more elegantly in a seperate file if desired.