### PR TITLE
[FIX] Simplemob grabs w/ lacertusol

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -42,10 +42,11 @@
 	..()
 
 	var/lacertusol = 0
-	for(var/datum/reagent/phororeagent/R in M.reagents.reagent_list)
-		if(R.id == "lacertusol")
-			lacertusol = 1
-			break
+	if(istype(M,/mob/living/carbon))
+		for(var/datum/reagent/phororeagent/R in M.reagents.reagent_list)
+			if(R.id == "lacertusol")
+				lacertusol = 1
+				break
 
 	// Should this all be in Touch()?
 	if(istype(H))


### PR DESCRIPTION
The phororeagent 'lacertusol' grants the subject increased damage with melee attacks. However the check for it causes a runtime for simplemobs because their default `reagents` value is always null and they have no `reagents_list`. This makes it fail explosively enough to completely prevent simplemobs from using grabs entirely.

This just adds a simple check for whether they're a carbon-subtype mob first, and if not then nothing happens.

Should fix #639.