### PR TITLE
[LOADOUT] AR-M Glasses & FR/EMS Jackets

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes_yw.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes_yw.dm
@@ -9,9 +9,9 @@
 	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician")
 
 /datum/gear/eyes/arglasses/med
-	display_name = "AR-M glasses (Med, SAR)"
+	display_name = "AR-M glasses (Medical)"
 	path = /obj/item/clothing/glasses/omnihud/med
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Search and Rescue")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Field Medic")
 
 /datum/gear/eyes/arglasses/all
 	display_name = "AR-B glasses (CD, HoP, BSG)"

--- a/code/modules/client/preference_setup/loadout/loadout_suit_yw.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_yw.dm
@@ -14,3 +14,12 @@
 /datum/gear/suit/victdress/red
 	display_name = "Victorian ladiescoat, Red"
 	path = /obj/item/clothing/suit/storage/victcoat/red
+
+/datum/gear/suit/roles/medical/ems_jacket
+	display_name = "first responder jacket"
+	path = /obj/item/clothing/suit/storage/toggle/fr_jacket
+	allowed_roles = list("Chief Medical Officer","Paramedic","Medical Doctor")
+
+/datum/gear/suit/roles/medical/ems_jacket/alt
+	display_name = "first responder jacket, alt."
+	path = /obj/item/clothing/suit/storage/toggle/fr_jacket/ems


### PR DESCRIPTION
Small PR to do two things in loadouts;
* Fix Field Medics being unable to take AR-M glasses (used wrong job title).
* Add the standard First Responder jacket & an alt. style for Paramedics, CMOs, and MDs.

Preview of the alt style for those curious;
![ems_jacket](https://user-images.githubusercontent.com/49700375/80452875-13f47200-891f-11ea-815c-453652931462.png)

I might be biased but I think it looks pretty nice and it's a shame to let another little bit of Polaris' stuff sit unused in the files.