### PR TITLE
Mapfixes Pass (Part 2)

### DIFF
--- a/code/game/jobs/access_datum_yw.dm
+++ b/code/game/jobs/access_datum_yw.dm
@@ -3,3 +3,15 @@
 	id = access_blueshield
 	desc = "Blueshield Special Access"
 	region = ACCESS_REGION_COMMAND
+
+var/const/access_sar = 68
+/datum/access/fieldmedic
+	id = access_sar
+	desc = "Search and Rescue"
+	region = ACCESS_REGION_MEDBAY
+	
+var/const/access_pathfinder = 69
+/datum/access/pathfinder
+	id = access_pathfinder
+	desc = "Pathfinder"
+	region = ACCESS_REGION_RESEARCH

--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -48441,7 +48441,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start{
-	name = "Search and Rescue"
+	name = "Field Medic"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48457,7 +48457,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start{
-	name = "Search and Rescue"
+	name = "Field Medic"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -51818,8 +51818,8 @@
 /area/cryogaia/station/excursion_dock)
 "bPo" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	req_access = list();
-	req_one_access = list(19,43,67)
+	name = "Exploration Briefing Room";
+	req_one_access = list(19,43,67,68,69)
 	},
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_meeting)
@@ -53085,14 +53085,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
 "bRN" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/research{
 	name = "Pathfinder's Office";
-	req_access = list(62);
-	req_one_access = list(62)
+	req_access = newlist();
+	req_one_access = list(69)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -53844,7 +53844,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
 "bTd" = (
 /obj/machinery/power/apc{
@@ -54694,7 +54694,7 @@
 /obj/structure/noticeboard/airlock{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
 "bUE" = (
 /obj/machinery/status_display,
@@ -55259,7 +55259,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
 "bVM" = (
 /obj/structure/table/rack/shelf,
@@ -55779,7 +55779,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
 "bWN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -56387,7 +56387,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
 "bXX" = (
 /obj/structure/cable/green{
@@ -56919,8 +56919,8 @@
 /area/cryogaia/station/explorer_prep)
 "bYU" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	req_access = list();
-	req_one_access = list(19,43,67)
+	name = "Exploration Prep Room";
+	req_one_access = list(19,43,67,68)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -57343,9 +57343,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monofloor{
-	dir = 1
-	},
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
 "bZM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -57722,17 +57720,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
-"cav" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monofloor,
-/area/cryogaia/station/explorer_prep)
 "caw" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 4
@@ -58019,17 +58006,6 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled,
-/area/cryogaia/station/explorer_prep)
-"caW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
 /area/cryogaia/station/explorer_prep)
 "caX" = (
 /obj/structure/table/rack/shelf,
@@ -58342,7 +58318,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
 "cbD" = (
 /obj/structure/table/bench/wooden,
@@ -58646,7 +58622,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
 "ccg" = (
 /obj/structure/cable/green{
@@ -58946,7 +58922,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
 "ccH" = (
 /obj/machinery/alarm{
@@ -63108,8 +63084,9 @@
 /area/maintenance/substation/civilian)
 "ety" = (
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list();
-	req_one_access = list(5)
+	name = "SAR Voidsuits";
+	req_access = newlist();
+	req_one_access = list(68)
 	},
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
@@ -117122,8 +117099,8 @@ bWM
 bXW
 bYU
 bZL
-cav
-caW
+bZL
+bZL
 cbC
 ccf
 ccG

--- a/maps/yw/cryogaia_defines.dm
+++ b/maps/yw/cryogaia_defines.dm
@@ -177,15 +177,6 @@
 
 	planet_datums_to_make = list(/datum/planet/borealis2)
 
-//Extra cameras that make use of the new outside area
-/obj/machinery/camera/auto_network/outside
-	name = "external security camera"
-	network = list(NETWORK_OUTSIDE)
-
-/obj/machinery/camera/auto_network/motion/outside
-	name = "external motion camera"
-	network = list(NETWORK_OUTSIDE)
-
 /datum/map/cryogaia/perform_map_generation()
 
 	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_CRYOGAIA_MINE, world.maxx, world.maxy) // Create the mining Z-level.

--- a/maps/yw/cryogaia_defines.dm
+++ b/maps/yw/cryogaia_defines.dm
@@ -177,6 +177,15 @@
 
 	planet_datums_to_make = list(/datum/planet/borealis2)
 
+//Extra cameras that make use of the new outside area
+/obj/machinery/camera/auto_network/outside
+	name = "external security camera"
+	network = list(NETWORK_OUTSIDE)
+
+/obj/machinery/camera/auto_network/motion/outside
+	name = "external motion camera"
+	network = list(NETWORK_OUTSIDE)
+
 /datum/map/cryogaia/perform_map_generation()
 
 	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_CRYOGAIA_MINE, world.maxx, world.maxy) // Create the mining Z-level.

--- a/maps/yw/cryogaia_jobs.dm
+++ b/maps/yw/cryogaia_jobs.dm
@@ -55,10 +55,10 @@ var/const/SAR 				=(1<<14)
 	minimal_player_age = 7
 	pto_type = PTO_EXPLORATION
 
-	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
-	minimal_access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
+	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway, access_pathfinder)
+	minimal_access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway, access_pathfinder)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder
-	job_description = "	The Pathfinder's job is to lead and manage expeditions, and is the primary authority on all off-station expeditions."
+	job_description = "The Pathfinder's job is to lead and manage expeditions, and is the primary authority on all off-station expeditions."
 
 /datum/job/pilot
 	title = "Pilot"
@@ -111,10 +111,10 @@ var/const/SAR 				=(1<<14)
 	minimal_player_age = 3
 	pto_type = PTO_EXPLORATION
 
-	access = list(access_medical, access_medical_equip, access_eva, access_maint_tunnels, access_external_airlocks)		//nerfs SAR access. Why the fuck do they have access to surgery and chemistry? They're not doctors, their medics.
-	minimal_access = list(access_medical, access_medical_equip, access_eva) //nerfs SAR access. Why the fuck do they have access to surgery and chemistry? They're not doctors, their medics.
+	access = list(access_medical, access_medical_equip, access_eva, access_maint_tunnels, access_external_airlocks, access_sar, access_chemistry) //restoring chemistry access. FMs need it to mix meds, and they're basically just glorified EMTs - who also have chemistry access.
+	minimal_access = list(access_medical, access_medical_equip, access_eva, access_sar)
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
-	job_description = "A Field medic works as the field doctor of expedition teams."
+	job_description = "A Field Medic works as the field doctor of expedition teams."
 
 /datum/job/offduty_exploration
 	title = "Off-duty Explorer"

--- a/maps/yw/structures/closets/misc.dm
+++ b/maps/yw/structures/closets/misc.dm
@@ -79,7 +79,7 @@
 	icon_opened = "medicalopen"
 	icon_broken = "medicalbroken"
 	icon_off = "medicaloff"
-	req_access = list(access_medical_equip)
+	req_access = list(access_sar)
 
 	starts_with = list(
 		/obj/item/weapon/storage/backpack/dufflebag/emt,

--- a/maps/yw/structures/closets/misc_vr.dm
+++ b/maps/yw/structures/closets/misc_vr.dm
@@ -96,7 +96,7 @@
 	icon_opened = "secureexpopen"
 	icon_broken = "secureexpbroken"
 	icon_off = "secureexpoff"
-	req_access = list(access_gateway)
+	req_access = list(access_pathfinder)
 
 	starts_with = list(
 		/obj/item/clothing/under/explorer,

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3657,8 +3657,6 @@
 #include "maps\southern_cross\loadout\loadout_head.dm"
 #include "maps\southern_cross\loadout\loadout_suit.dm"
 #include "maps\southern_cross\loadout\loadout_uniform.dm"
-#include "maps\southern_cross\structures\closets\misc.dm"
-#include "maps\southern_cross\structures\closets\misc_vr.dm"
 #include "maps\submaps\_helpers.dm"
 #include "maps\submaps\_readme.dm"
 #include "maps\submaps\engine_submaps\engine.dm"


### PR DESCRIPTION
I was going to hold off for a bit and do a pass on the cameras as well, but this is higher priority. Fixes a number of issues with exploration.

Changelog:
* Added Field Medic and Pathfinder access levels, and set some access levels for lockers and doors accordingly.
* Unloaded two old SC files that were duplicated and overwritten in the current setup.
* Fixed Field Medics spawning in the wrong location at roundstart due to misnamed landmarks.
* Restored Chemistry access for Field Medics. They need in to mix medicine for expeditions.
* Fixed some weird flooring in exploration.

I might redesign the prep room entirely later but this'll do for now.