### PR TITLE
Engineering Workshop Access Fix & Trader Pad Line Fix

### DIFF
--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -16815,12 +16815,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
@@ -16836,10 +16837,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
 	},
@@ -38145,19 +38143,28 @@
 /turf/simulated/floor/tiled/red,
 /area/security/security_equiptment_storage)
 "bsC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/workshop)
 "bsE" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Workshop";
-	req_access = newlist();
-	req_one_access = list(14,24)
+	req_one_access = list(10)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
@@ -38181,6 +38188,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
 	},
@@ -38190,6 +38204,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
@@ -38839,9 +38860,15 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
 "btX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/carpet,
 /area/engineering/workshop)
 "btY" = (
@@ -38851,6 +38878,9 @@
 "btZ" = (
 /obj/structure/bed/chair/sofa/right{
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/workshop)
@@ -39488,18 +39518,22 @@
 /obj/structure/bed/chair/sofa{
 	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Common Channel";
-	pixel_y = -21
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/workshop)
 "bvc" = (
 /obj/structure/bed/chair/sofa/corner{
 	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Common Channel";
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/workshop)
@@ -42648,8 +42682,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Workshop";
-	req_access = newlist();
-	req_one_access = list(14,24)
+	req_one_access = list(10)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42667,8 +42700,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Workshop";
-	req_access = newlist();
-	req_one_access = list(14,24)
+	req_one_access = list(10)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -62859,6 +62891,16 @@
 /obj/structure/sign/directions/science,
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/central_one)
+"dFM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/workshop)
 "dQb" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
@@ -63594,6 +63636,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/wall/rshull,
 /area/shuttle/security)
+"lhs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/workshop)
 "lya" = (
 /obj/machinery/light{
 	dir = 4;
@@ -64836,12 +64885,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
-"ylY" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engine Gas Storage"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
 
 (1,1,1) = {"
 aaa
@@ -94424,7 +94467,7 @@ bJX
 aHV
 aKw
 bqs
-bsC
+lhs
 btY
 bvb
 bro
@@ -94676,7 +94719,7 @@ bdI
 aHV
 aKw
 bqs
-bsC
+dFM
 btZ
 bvc
 bro
@@ -94950,7 +94993,7 @@ bPE
 bPE
 bPE
 bPE
-ylY
+bVg
 bVg
 bPE
 bPE

--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -18323,16 +18323,6 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating/snow/plating,
 /area/maintenance/auxsolarport)
-"aIF" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/simulated/floor/plating/snow/plating/cryogaia,
-/area/borealis2/outdoors/grounds/power)
 "aIK" = (
 /turf/simulated/wall/r_wall,
 /area/security/airlock)
@@ -19079,24 +19069,6 @@
 	},
 /turf/simulated/floor/plating/snow/plating,
 /area/maintenance/auxsolarport)
-"aKr" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 8
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 4
-	},
-/turf/simulated/floor/plating/snow/plating/cryogaia,
-/area/borealis2/outdoors/grounds/power)
 "aKs" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall,
@@ -33512,25 +33484,6 @@
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds)
-"bjY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/heavyduty{
-	icon_state = "2-4"
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 1
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 8
-	},
-/turf/simulated/floor/plating/snow/plating/cryogaia,
-/area/borealis2/outdoors/grounds/power)
 "bjZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -38150,10 +38103,6 @@
 /area/engineering/workshop)
 "bsE" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering Workshop";
-	req_one_access = list(10)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -38165,6 +38114,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Den"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
@@ -38760,21 +38712,6 @@
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/solars)
-"btO" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 8
-	},
-/obj/effect/floor_decal/snow/floor/edges,
-/turf/simulated/floor/plating/snow/plating/cryogaia,
-/area/borealis2/outdoors/grounds/power)
 "btP" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -39521,6 +39458,15 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "engidenshutters";
+	name = "Privacy Shutters";
+	pixel_x = -26;
+	pixel_y = -24;
+	req_access = newlist();
+	req_one_access = list(10)
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/workshop)
@@ -49502,7 +49448,7 @@
 	name = "Thermal Regulator Vent"
 	},
 /obj/machinery/door/airlock/glass_external/freezable{
-	req_access = list(48)
+	req_access = newlist()
 	},
 /turf/simulated/floor/plating/snow/plating,
 /area/borealis2/outdoors/grounds/traderpad)
@@ -52210,7 +52156,7 @@
 	id_tag = "trade_shuttle_dock_inner";
 	locked = 1;
 	name = "Dock One Internal Access";
-	req_access = list(13)
+	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/traderpad)
@@ -53746,7 +53692,13 @@
 /area/borealis2/outdoors/grounds/traderpad)
 "bTw" = (
 /obj/structure/fence/door,
-/turf/simulated/floor/outdoors/snow/snow/snow2/cryogaia,
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 4
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/gravsnow/cryogaia,
 /area/borealis2/outdoors/grounds)
 "bTx" = (
 /obj/structure/fence/corner{
@@ -54594,7 +54546,8 @@
 	id_tag = "trade_shuttle_dock_outer";
 	locked = 1;
 	name = "Dock One External Access";
-	req_access = list(13)
+	req_access = newlist();
+	req_one_access = list(13,52)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_diffuser,
@@ -54616,7 +54569,8 @@
 	id_tag = "trade_shuttle_dock_outer";
 	locked = 1;
 	name = "Dock One External Access";
-	req_access = list(13)
+	req_access = newlist();
+	req_one_access = list(13,52)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_diffuser,
@@ -62572,43 +62526,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
-"ckT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/snow/plating,
-/area/maintenance/auxsolarport)
-"ckU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/heavyduty,
-/turf/simulated/floor/plating/snow/plating,
-/area/maintenance/auxsolarport)
-"ckV" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 4
-	},
-/obj/effect/floor_decal/snow/floor/edges{
-	dir = 1
-	},
-/turf/simulated/floor/plating/snow/plating/cryogaia,
-/area/borealis2/outdoors/grounds/power)
 "ckY" = (
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/snow/plating/cryogaia,
@@ -62617,27 +62534,6 @@
 /obj/machinery/door/airlock/glass_external/public,
 /turf/simulated/floor/tiled,
 /area/borealis2/outdoors/grounds/entrance)
-"clb" = (
-/obj/effect/overlay/snow/floor,
-/obj/structure/cable/heavyduty{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/simulated/floor/plating,
-/area/borealis2/outdoors/grounds/traderpad)
-"clc" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/borealis2/outdoors/grounds/traderpad)
 "cld" = (
 /turf/simulated/floor/tiled,
 /area/borealis2/outdoors/grounds/entrance)
@@ -62767,6 +62663,16 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
+"cuo" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -30
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/borealis2/outdoors/grounds/traderpad)
 "cuv" = (
 /obj/machinery/light{
 	dir = 4;
@@ -62795,6 +62701,23 @@
 "cGu" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
+"cLk" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 1
+	},
+/obj/effect/floor_decal/snow/floor/edges,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 2;
+	flags = null
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "cLv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -62805,6 +62728,20 @@
 /obj/machinery/suit_cycler/medical,
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_prep)
+"cMv" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "engidenshutters";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/engineering/workshop)
 "cNr" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -62891,16 +62828,6 @@
 /obj/structure/sign/directions/science,
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/central_one)
-"dFM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/engineering/workshop)
 "dQb" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1380;
@@ -62928,6 +62855,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/security/armoury)
+"ehi" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "eie" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -63257,6 +63190,17 @@
 "hoH" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/briefing_room)
+"hsg" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/snow/floor/edges3{
+	icon_state = "gravsnow_edges";
+	dir = 1
+	},
+/obj/effect/floor_decal/snow/floor/edges3,
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "hug" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -63368,6 +63312,18 @@
 	},
 /turf/simulated/wall/rshull,
 /area/shuttle/security)
+"iTZ" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "jdu" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	icon_state = "warning_dust";
@@ -63383,6 +63339,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/security)
+"jiz" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "engidenshutters";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/engineering/workshop)
 "jpD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact-fuel";
@@ -63399,6 +63369,15 @@
 "jAq" = (
 /turf/simulated/wall/r_wall,
 /area/security/hangar)
+"jAZ" = (
+/obj/effect/floor_decal/snow/floor/edges,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 2;
+	flags = null
+	},
+/turf/simulated/floor/outdoors/snow/gravsnow/cryogaia,
+/area/borealis2/outdoors/grounds)
 "jDo" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -63532,6 +63511,23 @@
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/power)
+"knO" = (
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 2;
+	flags = null
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/snow/floor/edges3{
+	dir = 8
+	},
+/obj/effect/floor_decal/snow/floor/edges3{
+	dir = 4
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "kol" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -63636,13 +63632,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/wall/rshull,
 /area/shuttle/security)
-"lhs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/engineering/workshop)
 "lya" = (
 /obj/machinery/light{
 	dir = 4;
@@ -63908,12 +63897,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
-"ovS" = (
-/obj/machinery/door/airlock/glass_external/freezable{
-	req_access = list(48)
-	},
-/turf/simulated/floor/plating,
-/area/borealis2/outdoors/grounds/traderpad)
 "owi" = (
 /obj/item/device/geiger/wall{
 	dir = 1;
@@ -64010,6 +63993,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
+"pjA" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
+"pug" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "pxX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -64166,13 +64161,14 @@
 /obj/effect/floor_decal/snow/floor/edges{
 	dir = 8
 	},
-/obj/effect/floor_decal/snow/floor/edges,
 /obj/structure/cable/heavyduty{
 	icon_state = "1-4"
 	},
-/obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/power)
@@ -64257,6 +64253,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/security)
+"saK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/workshop)
 "sdy" = (
 /obj/structure/table/rack,
 /obj/machinery/door/window/brigdoor/northright{
@@ -64439,6 +64445,18 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"tIj" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "tKK" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8;
@@ -64522,6 +64540,12 @@
 /obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/outdoors/snow/snow/snow2/cryogaia,
 /area/borealis2/outdoors/grounds)
+"ujb" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/borealis2/outdoors/grounds/traderpad)
 "uAK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/heavyduty{
@@ -64556,6 +64580,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/security)
+"uJH" = (
+/obj/structure/cable/heavyduty,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/borealis2/outdoors/grounds/traderpad)
 "uOr" = (
 /obj/machinery/suit_cycler/security{
 	departments = list("Security EVA","Security");
@@ -64583,6 +64616,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
+"vdk" = (
+/obj/machinery/door/airlock/glass_external/freezable{
+	req_access = newlist()
+	},
+/turf/simulated/floor/plating,
+/area/borealis2/outdoors/grounds/traderpad)
 "vdJ" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -64693,6 +64732,17 @@
 /obj/item/device/gps/security,
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
+"vLQ" = (
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/gravsnow/cryogaia,
+/area/borealis2/outdoors/grounds)
 "vSR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64712,6 +64762,15 @@
 /obj/machinery/sleep_console,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/security)
+"wbg" = (
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 4
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/gravsnow/cryogaia,
+/area/borealis2/outdoors/grounds)
 "wdF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -64720,6 +64779,23 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/security/armoury)
+"wfH" = (
+/obj/structure/catwalk,
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/snow/floor/edges3{
+	dir = 8
+	},
+/obj/effect/floor_decal/snow/floor/edges3{
+	dir = 4
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "wnZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64734,6 +64810,33 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
+"wpI" = (
+/obj/effect/overlay/snow/floor,
+/obj/effect/floor_decal/snow/floor/edges3{
+	icon_state = "gravsnow_edges";
+	dir = 1
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/traderpad)
+"wpR" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 4
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 4
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "wwp" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -64766,6 +64869,13 @@
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds)
+"wIx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/workshop)
 "wII" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/steel,
@@ -64790,6 +64900,42 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
+"wPD" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 4
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 8
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 4
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
+"wQM" = (
+/obj/structure/railing{
+	dir = 2;
+	flags = null
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/snow/floor/edges{
+	dir = 1
+	},
+/obj/effect/floor_decal/snow/floor/edges,
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/power)
 "xch" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -75512,77 +75658,77 @@ aag
 aag
 aag
 aag
-bjY
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-btO
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
 aag
 aag
 aag
@@ -75764,7 +75910,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -75834,7 +75980,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -76016,7 +76162,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 aqD
@@ -76086,7 +76232,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -76268,7 +76414,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 arD
@@ -76338,7 +76484,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -76520,7 +76666,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqF
 aqF
@@ -76590,7 +76736,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -76772,7 +76918,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqG
 aum
@@ -76842,7 +76988,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -77024,7 +77170,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 arE
 arE
@@ -77094,7 +77240,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -77276,7 +77422,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 arD
@@ -77346,7 +77492,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -77528,7 +77674,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqF
 aqF
@@ -77598,7 +77744,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -77780,7 +77926,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqG
 aum
@@ -77850,7 +77996,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -78032,7 +78178,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 arE
 arE
@@ -78102,7 +78248,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -78284,7 +78430,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 arD
@@ -78354,7 +78500,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -78536,7 +78682,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqF
 aqF
@@ -78606,7 +78752,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -78788,7 +78934,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqG
 aum
@@ -78858,7 +79004,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -79040,7 +79186,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 arE
 arE
@@ -79110,7 +79256,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -79292,7 +79438,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 arD
@@ -79362,7 +79508,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -79544,7 +79690,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqF
 aqF
@@ -79614,7 +79760,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -79796,7 +79942,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqG
 aum
@@ -79866,7 +80012,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -80048,7 +80194,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 arE
 arE
@@ -80118,7 +80264,7 @@ aag
 aag
 aag
 aag
-aIF
+aag
 aag
 aag
 aag
@@ -80300,7 +80446,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 arD
@@ -80369,10 +80515,10 @@ aag
 aag
 aag
 aag
-bLF
-wLk
-bLF
-bLF
+aag
+aag
+aag
+aag
 aag
 aag
 aag
@@ -80552,7 +80698,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aqD
 aqD
@@ -80620,11 +80766,11 @@ aag
 aag
 aag
 aag
-aaY
-ovS
-clb
-clc
-bLF
+aag
+aag
+aag
+aag
+aag
 aag
 aag
 aag
@@ -80804,7 +80950,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -80872,8 +81018,8 @@ aag
 aag
 aag
 aag
-mjH
-bLF
+aag
+aag
 bLF
 bLF
 bLF
@@ -81056,7 +81202,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -81124,7 +81270,7 @@ aag
 aag
 aag
 aag
-mjH
+aag
 aag
 bLF
 bMZ
@@ -81308,7 +81454,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -81372,11 +81518,11 @@ aag
 aag
 aag
 aag
-aag
 bsy
 aag
 aag
-mjH
+aag
+aag
 aag
 bLF
 bNa
@@ -81560,7 +81706,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -81628,7 +81774,7 @@ aHb
 aHb
 aHb
 aHb
-buX
+aHb
 aHb
 bLG
 bNb
@@ -81812,7 +81958,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -81880,7 +82026,7 @@ bww
 bww
 bww
 bww
-bww
+buX
 bww
 bLG
 bNb
@@ -82064,7 +82210,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -82131,8 +82277,8 @@ aag
 aag
 aag
 aag
-aag
 bsy
+mjH
 aag
 bLF
 bNa
@@ -82316,7 +82462,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -82384,7 +82530,7 @@ aag
 aag
 aag
 aag
-aag
+mjH
 aag
 bLF
 bMZ
@@ -82568,7 +82714,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -82636,7 +82782,7 @@ aag
 aag
 aag
 aag
-aag
+mjH
 aag
 bLF
 bLF
@@ -82820,7 +82966,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -82888,13 +83034,13 @@ aag
 aag
 aag
 aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
+btM
+wbg
+vdk
+ujb
+uJH
+cuo
+bLF
 aag
 bTr
 bWc
@@ -83072,7 +83218,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -83140,13 +83286,13 @@ aag
 aag
 aag
 aag
+btM
 aag
-aag
-aag
-aag
-aag
-aag
-aag
+bLF
+wLk
+bLF
+bLF
+bLF
 aag
 bTr
 bWc
@@ -83324,7 +83470,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -83392,14 +83538,14 @@ aag
 aag
 aag
 aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
+aba
+wbg
+wbg
+hsg
+wbg
+wbg
+wbg
+aHb
 bTr
 bWd
 bXR
@@ -83576,7 +83722,7 @@ aag
 aag
 aag
 aag
-bNw
+aag
 aag
 aag
 aag
@@ -83647,11 +83793,11 @@ aag
 aag
 aag
 aag
+wQM
 aag
 aag
 aag
-aag
-aag
+btM
 bTr
 bWc
 bXR
@@ -83828,29 +83974,29 @@ aag
 aag
 aag
 aag
-ckV
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-aKr
-ckT
-ckU
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aHP
+aID
 aJB
 aKp
 aHP
@@ -83899,11 +84045,11 @@ aag
 aag
 aag
 aag
+wQM
 aag
 aag
 aag
-aag
-aag
+btM
 bTr
 bWc
 bXR
@@ -84151,13 +84297,13 @@ aag
 aag
 aag
 aag
+cLk
 aag
 aag
 aag
-aag
-aag
+aba
 bTw
-bWc
+wpI
 bXR
 bXR
 bXR
@@ -84403,7 +84549,7 @@ aag
 aag
 aag
 aag
-aag
+cLk
 aag
 aag
 aag
@@ -84655,7 +84801,7 @@ aag
 aag
 aag
 aag
-abq
+iTZ
 abq
 abq
 aag
@@ -84907,7 +85053,7 @@ aag
 aag
 abq
 abq
-abq
+pug
 abq
 abq
 abq
@@ -85149,8 +85295,8 @@ aag
 aag
 aag
 aag
-btM
-avu
+vLQ
+jAZ
 bsy
 aag
 aag
@@ -85159,7 +85305,7 @@ aag
 abq
 abq
 abq
-abq
+pug
 abq
 abq
 abq
@@ -85397,21 +85543,21 @@ qaj
 qaj
 qaj
 rrE
-aag
-aag
-aag
-aag
-btM
-avu
-aag
-aag
-aag
-aag
-aag
-abq
-abq
-abq
-abq
+wPD
+wPD
+wPD
+wPD
+wfH
+knO
+wPD
+wPD
+wpR
+wpR
+tIj
+pjA
+pjA
+pjA
+ehi
 abq
 abq
 abq
@@ -85653,8 +85799,8 @@ aag
 aag
 aag
 aag
-btM
-avu
+vLQ
+jAZ
 aag
 aag
 aag
@@ -93711,9 +93857,9 @@ mNy
 aHV
 aKw
 bqs
-brs
-brs
-brs
+cMv
+cMv
+cMv
 bro
 bxy
 byT
@@ -94467,7 +94613,7 @@ bJX
 aHV
 aKw
 bqs
-lhs
+wIx
 btY
 bvb
 bro
@@ -94719,7 +94865,7 @@ bdI
 aHV
 aKw
 bqs
-dFM
+saK
 btZ
 bvc
 bro
@@ -94973,7 +95119,7 @@ dWP
 jYk
 bsE
 bro
-brs
+jiz
 bro
 bxD
 bxD


### PR DESCRIPTION
Station Engineers are not authorized to enter the Engineering Workshop. This is because the workshop doors require access level permissions 14 & 24, which limits it to Atmospherics and the CE.

This seems like an oversight, and also means that the comfy little den in the back of engineering is inaccessible.

The power line running out to the trader landing pad is also busted at the solars shed end, so ~~I'm going to tinker and see if I can rig up a fix~~ I rerouted the entire power line and fixed it.

- [x] Fix engineers being locked out of the workshop.
- [x] Fix lack of airvent/etc. in the den and a missing shutter in engine gas storage.
- [x] Installed privacy shutters in the den and renamed the door.
- [x] Fix the trader power line for reals this time.