### PR TITLE
Fixes Sec Pilots not getting PTO

### DIFF
--- a/code/game/jobs/job/security_yw.dm
+++ b/code/game/jobs/job/security_yw.dm
@@ -29,6 +29,7 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks, access_secpilot)
 	minimal_player_age = 7
 	outfit_type = /decl/hierarchy/outfit/job/security/pilot
+	pto_type = PTO_SECURITY
 
 	job_description = "Tasked with flying, operating, and sometimes even maintaining small spacecraft and personal exosuits such as the Durand or Gygax, \
 						Security Pilots are responsible for transporting criminals to more permanent holding facilities, and patrolling \


### PR DESCRIPTION
I somehow managed to overlook PTO type assignment when setting the job up and never doublechecked it. Oops!

Should be all good now.