### PR TITLE
[FIX] Restores CAMERA_DEFAULT network to monitors

### DIFF
--- a/maps/yw/cryogaia_defines.dm
+++ b/maps/yw/cryogaia_defines.dm
@@ -74,7 +74,7 @@
 							NETWORK_ENGINEERING,
 							NETWORK_SUBSTATIONS,
 							NETWORK_EXPLORATION,
-							//NETWORK_DEFAULT,  //Is this even used for anything? Robots show up here, but they show up in ROBOTS network too,
+							NETWORK_DEFAULT,
 							NETWORK_MEDICAL,
 							NETWORK_MINE,
 							NETWORK_OUTSIDE,


### PR DESCRIPTION
I guess default cam networks got shuffled around at some point or something, and now a bunch of cameras dropped off the networks. This ought to fix that.