### PR TITLE
[SEMI-URGENT] Fixes hanging/crashing server when using the Export-Chatlog verb in OOC

### DIFF
--- a/code/modules/vchat/html/vchat.html
+++ b/code/modules/vchat/html/vchat.html
@@ -137,7 +137,7 @@
 								</div>
 							</div>
 						</div>
-						<!-- <button class="ui button" @click="save_chatlog">Export Chatlog</button> YW EDIT: disabled until we can fix the lag -->
+						<button class="ui button" @click="save_chatlog">Export Chatlog</button>
 					</div>
 				</div>
 			</div>

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -379,7 +379,6 @@ var/to_chat_src
 		var/list/tojson = list("time" = time, "message" = message);
 		target << output(jsEncode(tojson), "htmloutput:putmessage")
 
-/* YW EDIT: disabled until we can fix the lag
 /client/proc/vchat_export_log()
 	set name = "Export chatlog"
 	set category = "OOC"
@@ -408,6 +407,7 @@ var/to_chat_src
 	// Write the messages to the log
 	for(var/list/result in results)
 		o_file << "[result["message"]]<br>"
+		CHECK_TICK
 
 	o_file << "</body></html>"
 
@@ -420,4 +420,3 @@ var/to_chat_src
 			spawn(1 MINUTE)
 				if(!fdel(o_file))
 					log_debug("Warning: [ckey]'s chatlog could not be deleted one minute after file transfer was initiated. It is located at 'data/chatlog_tmp/[ckey]_chat_log' and will need to be manually removed.")
-*/

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -133,7 +133,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	send_playerinfo()
 	load_database()
 
-	//YW EDIT: disabled until we can fix the lag: owner.verbs += /client/proc/vchat_export_log
+	owner.verbs += /client/proc/vchat_export_log
 
 //Perform DB shenanigans
 /datum/chatOutput/proc/load_database()


### PR DESCRIPTION
As per title. Does slow down the export, but will prevent the server or whatever from trying to export 2000+ (or however many) lines of chat at once.

Up-upstream: https://github.com/PolarisSS13/Polaris/pull/7353