### PR TITLE
ERT Equipment Updates

### DIFF
--- a/maps/yw/cryogaia-01-centcomm.dmm
+++ b/maps/yw/cryogaia-01-centcomm.dmm
@@ -5540,12 +5540,6 @@
 /area/centcom/specops)
 "nr" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
@@ -7229,9 +7223,18 @@
 /area/centcom/specops)
 "qA" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -7245,6 +7248,42 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/effect/floor_decal/industrial/outline/blue,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
+"qC" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
+"qD" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
+"qE" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "specops_centcom_dock";
+	name = "docking port controller";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_one_access = list(103);
+	tag_door = "specops_centcom_dock_door"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -21220,6 +21259,15 @@
 	},
 /turf/unsimulated/wall,
 /area/space)
+"US" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "UU" = (
 /obj/item/toy/chess/pawn_white,
 /turf/simulated/floor/holofloor/wmarble,
@@ -21243,14 +21291,6 @@
 /obj/item/toy/chess/rook_black,
 /turf/simulated/floor/holofloor/bmarble,
 /area/holodeck/source_chess)
-"Vi" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_r"
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/specops)
 "Vm" = (
 /obj/effect/floor_decal/sign/small_g,
 /turf/simulated/floor/holofloor/wood,
@@ -21263,21 +21303,6 @@
 /obj/item/toy/chess/bishop_white,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
-"VI" = (
-/obj/structure/table/rack,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/space)
 "VK" = (
 /obj/item/toy/chess/pawn_black,
 /turf/simulated/floor/holofloor/wmarble,
@@ -21286,24 +21311,6 @@
 /obj/effect/floor_decal/sign/small_3,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
-"VS" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/space)
 "VU" = (
 /obj/effect/floor_decal/sign/small_b,
 /turf/simulated/floor/holofloor/wood,
@@ -21355,15 +21362,6 @@
 /obj/effect/floor_decal/sign/small_1,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
-"Xd" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/responseteam/engineer,
-/obj/item/clothing/suit/space/void/responseteam/engineer,
-/obj/item/clothing/suit/space/void/responseteam/engineer,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/specops)
 "Xj" = (
 /obj/effect/floor_decal/sign/small_2,
 /turf/simulated/floor/holofloor/wood,
@@ -21372,6 +21370,17 @@
 /obj/item/toy/chess/queen_white,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
+"Xs" = (
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "XK" = (
 /obj/effect/floor_decal/sign/small_4,
 /turf/simulated/floor/holofloor/wood,
@@ -21384,18 +21393,19 @@
 /obj/item/toy/chess/knight_white,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
-"XR" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/responseteam/security,
-/obj/item/clothing/suit/space/void/responseteam/security,
-/obj/item/clothing/suit/space/void/responseteam/security,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+"XS" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 32
 	},
-/area/centcom/specops)
-"Yb" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/responseteam/command,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -21424,18 +21434,18 @@
 /obj/effect/floor_decal/sign/small_a,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
-"Yp" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
+"Yt" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/command,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
-/area/space)
+/area/centcom/specops)
 "Yy" = (
 /obj/item/toy/chess/king_black,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
-"YB" = (
+"YA" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
 	icon_state = "propulsion"
@@ -21446,19 +21456,14 @@
 "YE" = (
 /turf/space/transit/east,
 /area/space)
-"YV" = (
-/obj/structure/table/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+"YH" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_r"
 	},
-/area/space)
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/specops)
 "Za" = (
 /obj/effect/floor_decal/sign/small_5,
 /turf/simulated/floor/holofloor/wood,
@@ -21483,20 +21488,6 @@
 /obj/effect/floor_decal/sign/small_6,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
-"Zs" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "specops_centcom_dock";
-	name = "docking port controller";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_one_access = list(103);
-	tag_door = "specops_centcom_dock_door"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/space)
 "Zv" = (
 /obj/item/toy/chess/king_white,
 /turf/simulated/floor/holofloor/bmarble,
@@ -21532,18 +21523,28 @@
 	},
 /turf/space/transit/east,
 /area/space)
-"ZF" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/space)
 "ZM" = (
 /obj/effect/floor_decal/sign/small_7,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
-"ZP" = (
-/turf/simulated/shuttle/wall/dark/hard_corner,
-/area/space)
+"ZR" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
+"ZV" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/security,
+/obj/item/clothing/suit/space/void/responseteam/security,
+/obj/item/clothing/suit/space/void/responseteam/security,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 
 (1,1,1) = {"
 ab
@@ -38270,7 +38271,7 @@ mT
 mT
 nq
 pW
-Xd
+US
 pV
 qy
 rc
@@ -39776,7 +39777,7 @@ nJ
 nW
 mT
 mT
-XR
+ZV
 nq
 mT
 mT
@@ -40790,8 +40791,8 @@ pl
 pu
 mO
 qd
+ZR
 qA
-VS
 mO
 mO
 mO
@@ -41043,13 +41044,13 @@ mT
 mO
 nq
 nq
-ZP
+mO
 mO
 kE
-YB
-YB
-YB
-Vi
+YA
+YA
+YA
+YH
 tw
 aa
 aa
@@ -41292,10 +41293,10 @@ oZ
 pg
 mT
 mT
-mT
+Xs
 qe
 qB
-ZP
+mO
 mO
 mB
 rB
@@ -41547,7 +41548,7 @@ mT
 mT
 mT
 mT
-VI
+qC
 nq
 mB
 rW
@@ -41799,7 +41800,7 @@ mT
 mT
 mT
 mT
-Yp
+qD
 nq
 mB
 rX
@@ -42043,7 +42044,7 @@ ny
 ny
 nq
 mO
-oy
+XS
 mT
 mT
 pn
@@ -42051,7 +42052,7 @@ pn
 pn
 mT
 mT
-Zs
+qE
 mO
 mB
 rY
@@ -42303,7 +42304,7 @@ pv
 pG
 mT
 mT
-ZF
+mT
 rd
 rz
 rZ
@@ -42555,7 +42556,7 @@ nv
 pH
 mT
 mT
-ZF
+mT
 rd
 rz
 rZ
@@ -42807,7 +42808,7 @@ nv
 pI
 mT
 mT
-ZF
+mT
 mO
 mB
 rZ
@@ -43059,7 +43060,7 @@ pq
 pq
 mT
 mT
-Yp
+qD
 mO
 mB
 sa
@@ -43298,7 +43299,7 @@ aa
 aa
 aa
 mO
-Yb
+Yt
 mT
 mT
 ob
@@ -43311,7 +43312,7 @@ mT
 mT
 mT
 mT
-VI
+qC
 mO
 mB
 sb
@@ -43563,7 +43564,7 @@ mT
 mT
 mT
 mT
-YV
+qB
 mO
 mB
 sc
@@ -43815,7 +43816,7 @@ mT
 pJ
 qf
 qe
-ZF
+mT
 mO
 aa
 mB

--- a/maps/yw/cryogaia-01-centcomm.dmm
+++ b/maps/yw/cryogaia-01-centcomm.dmm
@@ -3466,14 +3466,6 @@
 	icon_state = "gravsnow_corner"
 	},
 /area/syndicate_mothership)
-"ja" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_l"
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/specops)
 "jb" = (
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/shuttle/floor/darkred,
@@ -4154,15 +4146,7 @@
 "kE" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion"
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/specops)
-"kF" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_r"
+	icon_state = "burst_l"
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -6767,11 +6751,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
-"pE" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/centcom/specops)
 "pF" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 5
@@ -7250,18 +7229,9 @@
 /area/centcom/specops)
 "qA" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -7275,42 +7245,6 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/specops)
-"qC" = (
-/obj/structure/table/rack,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/specops)
-"qD" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/centcom/specops)
-"qE" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "specops_centcom_dock";
-	name = "docking port controller";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_one_access = list(103);
-	tag_door = "specops_centcom_dock_door"
-	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -21309,6 +21243,14 @@
 /obj/item/toy/chess/rook_black,
 /turf/simulated/floor/holofloor/bmarble,
 /area/holodeck/source_chess)
+"Vi" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/specops)
 "Vm" = (
 /obj/effect/floor_decal/sign/small_g,
 /turf/simulated/floor/holofloor/wood,
@@ -21321,6 +21263,21 @@
 /obj/item/toy/chess/bishop_white,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
+"VI" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/space)
 "VK" = (
 /obj/item/toy/chess/pawn_black,
 /turf/simulated/floor/holofloor/wmarble,
@@ -21329,6 +21286,24 @@
 /obj/effect/floor_decal/sign/small_3,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
+"VS" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/space)
 "VU" = (
 /obj/effect/floor_decal/sign/small_b,
 /turf/simulated/floor/holofloor/wood,
@@ -21380,6 +21355,15 @@
 /obj/effect/floor_decal/sign/small_1,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
+"Xd" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "Xj" = (
 /obj/effect/floor_decal/sign/small_2,
 /turf/simulated/floor/holofloor/wood,
@@ -21400,6 +21384,22 @@
 /obj/item/toy/chess/knight_white,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
+"XR" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/security,
+/obj/item/clothing/suit/space/void/responseteam/security,
+/obj/item/clothing/suit/space/void/responseteam/security,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
+"Yb" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/command,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/centcom/specops)
 "Yc" = (
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
@@ -21424,12 +21424,40 @@
 /obj/effect/floor_decal/sign/small_a,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
+"Yp" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/space)
 "Yy" = (
 /obj/item/toy/chess/king_black,
 /turf/simulated/floor/holofloor/wmarble,
 /area/holodeck/source_chess)
+"YB" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/specops)
 "YE" = (
 /turf/space/transit/east,
+/area/space)
+"YV" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
 /area/space)
 "Za" = (
 /obj/effect/floor_decal/sign/small_5,
@@ -21455,6 +21483,20 @@
 /obj/effect/floor_decal/sign/small_6,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
+"Zs" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "specops_centcom_dock";
+	name = "docking port controller";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_one_access = list(103);
+	tag_door = "specops_centcom_dock_door"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/space)
 "Zv" = (
 /obj/item/toy/chess/king_white,
 /turf/simulated/floor/holofloor/bmarble,
@@ -21490,10 +21532,18 @@
 	},
 /turf/space/transit/east,
 /area/space)
+"ZF" = (
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/space)
 "ZM" = (
 /obj/effect/floor_decal/sign/small_7,
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chess)
+"ZP" = (
+/turf/simulated/shuttle/wall/dark/hard_corner,
+/area/space)
 
 (1,1,1) = {"
 ab
@@ -37967,7 +38017,7 @@ mO
 mT
 mT
 nq
-pV
+mT
 mT
 mT
 mT
@@ -38220,11 +38270,11 @@ mT
 mT
 nq
 pW
+Xd
+pV
 qy
 rc
 ru
-mT
-mT
 mT
 sX
 sX
@@ -38713,7 +38763,7 @@ aa
 mO
 mU
 mT
-mT
+oU
 mT
 mT
 mT
@@ -39222,7 +39272,7 @@ nH
 nU
 mT
 mT
-oU
+oV
 nq
 mT
 mT
@@ -39474,7 +39524,7 @@ nI
 nV
 mT
 mT
-oV
+oW
 nq
 mT
 mT
@@ -39726,7 +39776,7 @@ nJ
 nW
 mT
 mT
-oW
+XR
 nq
 mT
 mT
@@ -39982,7 +40032,7 @@ oX
 mO
 pl
 pu
-pE
+mO
 qc
 mT
 mT
@@ -40741,6 +40791,7 @@ pu
 mO
 qd
 qA
+VS
 mO
 mO
 mO
@@ -40748,7 +40799,6 @@ mO
 mO
 mO
 mO
-aa
 aa
 aa
 aa
@@ -40993,14 +41043,14 @@ mT
 mO
 nq
 nq
+ZP
 mO
-ja
 kE
-kE
-kE
-kF
+YB
+YB
+YB
+Vi
 tw
-aa
 aa
 aa
 aa
@@ -41245,6 +41295,7 @@ mT
 mT
 qe
 qB
+ZP
 mO
 mB
 rB
@@ -41252,7 +41303,6 @@ sd
 sd
 mB
 tw
-aa
 aa
 aa
 aa
@@ -41496,7 +41546,8 @@ mT
 mT
 mT
 mT
-qC
+mT
+VI
 nq
 mB
 rW
@@ -41504,7 +41555,6 @@ se
 sq
 mB
 tw
-aa
 aa
 aa
 aa
@@ -41748,7 +41798,8 @@ mT
 mT
 mT
 mT
-qD
+mT
+Yp
 nq
 mB
 rX
@@ -41756,7 +41807,6 @@ rZ
 sr
 mB
 tw
-aa
 aa
 aa
 aa
@@ -42000,7 +42050,8 @@ pn
 pn
 pn
 mT
-qE
+mT
+Zs
 mO
 mB
 rY
@@ -42008,7 +42059,6 @@ rZ
 sB
 mB
 tw
-aa
 aa
 aa
 aa
@@ -42253,6 +42303,7 @@ pv
 pG
 mT
 mT
+ZF
 rd
 rz
 rZ
@@ -42260,7 +42311,6 @@ rZ
 sB
 mB
 tw
-aa
 aa
 aa
 aa
@@ -42505,6 +42555,7 @@ nv
 pH
 mT
 mT
+ZF
 rd
 rz
 rZ
@@ -42512,7 +42563,6 @@ rZ
 sB
 mB
 tw
-aa
 aa
 aa
 aa
@@ -42757,6 +42807,7 @@ nv
 pI
 mT
 mT
+ZF
 mO
 mB
 rZ
@@ -42764,7 +42815,6 @@ rZ
 sB
 mB
 tw
-aa
 aa
 aa
 aa
@@ -43008,7 +43058,8 @@ pq
 pq
 pq
 mT
-qD
+mT
+Yp
 mO
 mB
 sa
@@ -43016,7 +43067,6 @@ rZ
 sB
 mB
 tw
-aa
 aa
 aa
 aa
@@ -43248,7 +43298,7 @@ aa
 aa
 aa
 mO
-nt
+Yb
 mT
 mT
 ob
@@ -43260,7 +43310,8 @@ mT
 mT
 mT
 mT
-qC
+mT
+VI
 mO
 mB
 sb
@@ -43268,7 +43319,6 @@ rZ
 sC
 mB
 tw
-aa
 aa
 aa
 aa
@@ -43512,7 +43562,8 @@ mT
 mT
 mT
 mT
-qB
+mT
+YV
 mO
 mB
 sc
@@ -43520,7 +43571,6 @@ so
 sc
 mB
 tw
-aa
 aa
 aa
 aa
@@ -43752,10 +43802,10 @@ aa
 aa
 aa
 mO
-nv
-nA
-nM
-od
+mT
+mT
+mT
+mT
 mO
 oA
 mT
@@ -43765,6 +43815,7 @@ mT
 pJ
 qf
 qe
+ZF
 mO
 aa
 mB
@@ -43772,7 +43823,6 @@ sp
 mB
 aa
 tw
-aa
 aa
 aa
 aa
@@ -44004,10 +44054,10 @@ aa
 aa
 aa
 mO
-mO
-mO
-mO
-mO
+nt
+nA
+nM
+od
 mO
 nh
 mT
@@ -44255,12 +44305,12 @@ aa
 aa
 mO
 mO
-nh
-mT
-mT
-mT
-mT
-mT
+mO
+mO
+mO
+mO
+mO
+mO
 mT
 mT
 mT


### PR DESCRIPTION
Issues ERT teams with sets of the somewhat-new Hephaestus MkVII C/E/M/S ERT Voidsuits, added [upstream in VS8308](https://github.com/VOREStation/VOREStation/pull/8308). Also drops in a set of suit coolers and switches the magboots out for fancier adv. magboots in a more visible location.

The voidsuit itself has autoadaptive tech (no cycler needed), with high armor values, and an integral+unremovable helmet. Preview:
![ert-voidsuits-fin](https://user-images.githubusercontent.com/49700375/85087561-bfaa9780-b1d5-11ea-9ca7-fa0b933a5fad.gif)

Had to do a tiny bit of layout shuffling to the ERT station but everything should (fingers crossed) be fine.