### PR TITLE
add handling for inconsistent chem definitions

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -683,6 +683,9 @@
 
 					if(isnull(gene_chem[i])) gene_chem[i] = 0
 
+					if(chems[rid].len < i) //YW Edit: allows plants whose reagents have not been defined uniformly to splice properly
+						continue
+
 					if(chems[rid][i])
 						chems[rid][i] = max(1,round((gene_chem[i] + chems[rid][i])/2))
 					else


### PR DESCRIPTION
Basically just added two to `apply_gene` that allows the function to avoid a range error when splicing genes with common chems defined differently (e.g. `nutriment = list(1)` and `nutriment = list(1, 25)`). Hopefully this should fix many issues with splicing various plants that define nutriment and other chems uniquely.