### PR TITLE
Mapping Updates

### DIFF
--- a/code/modules/xenoarcheaology/misc.dm
+++ b/code/modules/xenoarcheaology/misc.dm
@@ -76,6 +76,20 @@
 	P.overlays = list("paper_stamped_rd")
 	src.contents += P
 
+//YW ADD START
+/obj/structure/noticeboard/blueshield
+	notices = 1
+	icon_state = "nboard01"
+
+/obj/structure/noticeboard/nanite/New()
+	var/obj/item/weapon/paper/P = new()
+	P.name = "Staff Notice: Blueshield Special Reserve"
+	P.info = "<br>This secure storage unit is intended to be used for special equipment specifically for the use of Blueshield Agents in the event of a Code Red threat to Heads of Staff. Heads of Staff found 'commandeering' this equipment can expect to be severely reprimanded.<br><br>(Underneath, there is a messy handwritten addition.)<br><i>Sorry, we haven't had time or spare funds to issue anything yet. You know how frontier budgets are! Sit tight, champ. -Z.V.</i>"
+	P.stamped = list(/obj/item/weapon/stamp/centcomm)
+	P.overlays = list("paper_stamped_cent")
+	src.contents += P
+//YW ADD END
+
 /obj/structure/noticeboard/library
 	notices = 2
 	icon_state = "nboard02"

--- a/maps/yw/cryogaia-01-centcomm.dmm
+++ b/maps/yw/cryogaia-01-centcomm.dmm
@@ -21264,6 +21264,7 @@
 /obj/item/clothing/suit/space/void/responseteam/engineer,
 /obj/item/clothing/suit/space/void/responseteam/engineer,
 /obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -21299,6 +21300,17 @@
 /obj/item/toy/chess/queen_black,
 /turf/simulated/floor/holofloor/bmarble,
 /area/holodeck/source_chess)
+"Vr" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/janitor,
+/obj/item/clothing/suit/space/void/responseteam/janitor,
+/obj/item/clothing/suit/space/void/responseteam/janitor,
+/obj/item/clothing/suit/space/void/responseteam/janitor,
+/turf/unsimulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/centcom/specops)
 "Vy" = (
 /obj/item/toy/chess/bishop_white,
 /turf/simulated/floor/holofloor/wmarble,
@@ -21532,12 +21544,14 @@
 /obj/item/clothing/suit/space/void/responseteam/medical,
 /obj/item/clothing/suit/space/void/responseteam/medical,
 /obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/centcom/specops)
 "ZV" = (
 /obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/responseteam/security,
 /obj/item/clothing/suit/space/void/responseteam/security,
 /obj/item/clothing/suit/space/void/responseteam/security,
 /obj/item/clothing/suit/space/void/responseteam/security,
@@ -45568,7 +45582,7 @@ aa
 aa
 aa
 mO
-nB
+Vr
 nB
 oe
 mO
@@ -45820,7 +45834,7 @@ aa
 aa
 aa
 mO
-nC
+of
 nB
 of
 mO
@@ -46072,9 +46086,9 @@ aa
 aa
 aa
 mO
-nD
-nO
-og
+nC
+nB
+of
 mO
 oC
 pa
@@ -46324,9 +46338,9 @@ aa
 aa
 aa
 mO
-mO
-mO
-mO
+nD
+nO
+og
 mO
 oC
 pa
@@ -46575,10 +46589,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+mO
+mO
+mO
+mO
 mO
 oD
 nB

--- a/maps/yw/cryogaia-02-mining.dmm
+++ b/maps/yw/cryogaia-02-mining.dmm
@@ -1722,7 +1722,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/hallway)
 "dU" = (
-/obj/machinery/vending/assist,
+/obj/machinery/vending/assist{
+	icon_state = "generic";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/hallway)
 "dV" = (
@@ -3103,7 +3106,10 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
 	},
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola{
+	icon_state = "Soda_Machine";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
 "gV" = (
@@ -3569,9 +3575,12 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
 	},
-/obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
+	},
+/obj/machinery/vending/snack{
+	icon_state = "snack";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
@@ -7271,7 +7280,8 @@
 "oT" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenoflora Storage";
-	req_access = list(55)
+	req_access = null;
+	req_one_access = list(77,52)
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/blue{
@@ -8779,7 +8789,8 @@
 	},
 /obj/machinery/door/airlock/glass_research{
 	name = "Xenoflora Research";
-	req_access = list(55)
+	req_access = null;
+	req_one_access = list(77,52)
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9874,7 +9885,8 @@
 	},
 /obj/machinery/door/airlock/glass_research{
 	name = "Xenoflora Research";
-	req_access = list(55)
+	req_access = null;
+	req_one_access = list(77,52)
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/hydro,
@@ -10372,7 +10384,8 @@
 /area/rnd/xenobiology/xenoflora)
 "uz" = (
 /obj/machinery/vending/hydronutrients{
-	categories = 3
+	icon_state = "nutri_generic";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -10953,7 +10966,10 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "vy" = (
-/obj/machinery/seed_storage/xenobotany,
+/obj/machinery/seed_storage/xenobotany{
+	icon_state = "seeds";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "vz" = (
@@ -19702,11 +19718,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/outpost/mining_main/airlock)
 "Mb" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack{
+	icon_state = "snack";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/break_room)
 "Mc" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	icon_state = "cigs";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/break_room)
 "Md" = (
@@ -20696,10 +20718,10 @@
 /turf/simulated/wall,
 /area/maintenance/shelter3)
 "Op" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(7,29)
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/shelter3)
 "Oq" = (
@@ -20775,15 +20797,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/shelter3)
 "OB" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(48)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
+	},
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/shelter3)

--- a/maps/yw/cryogaia-04-maintenance.dmm
+++ b/maps/yw/cryogaia-04-maintenance.dmm
@@ -3370,13 +3370,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aid" = (
-/obj/structure/stairs/west,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/maintenance/lowfloor1)
 "aie" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10624,12 +10617,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/fore)
-"axz" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/maintenance/lowfloor1)
 "axA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13421,6 +13408,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/aft)
 "aDq" = (
@@ -15396,10 +15387,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/aft)
-"aHW" = (
-/obj/structure/sign/poster,
-/turf/simulated/wall,
-/area/crew_quarters/sleep/cryo)
 "aHX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -18763,17 +18750,8 @@
 "aPU" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/security_lower)
-"aPV" = (
-/obj/machinery/door/airlock/maintenance/sec{
-	name = "Security Maintenance";
-	req_access = list(63);
-	req_one_access = list(1)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel,
-/area/maintenance/security_lower)
 "aPW" = (
-/turf/simulated/mineral/cave,
+/turf/simulated/floor/plating,
 /area/security/prison)
 "aPX" = (
 /obj/structure/cable/green{
@@ -19173,9 +19151,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor,
 /area/maintenance/starboard)
-"aQJ" = (
-/turf/simulated/mineral/cave,
-/area/security/range)
 "aQK" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/target_stake,
@@ -23481,13 +23456,19 @@
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "aYZ" = (
-/obj/machinery/vending/hydronutrients,
+/obj/machinery/vending/hydronutrients{
+	icon_state = "nutri_generic";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "aZa" = (
-/obj/machinery/seed_storage/garden,
 /obj/machinery/camera/network/prison{
 	c_tag = "Brig East";
+	dir = 1
+	},
+/obj/machinery/seed_storage/garden{
+	icon_state = "seeds";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -27488,13 +27469,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
-"bgY" = (
-/obj/item/device/geiger/wall{
-	dir = 4;
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/sleep/cryo)
 "bgZ" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/Dorm_2)
@@ -28526,6 +28500,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "biZ" = (
@@ -28592,6 +28570,10 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "bjg" = (
@@ -32018,11 +32000,7 @@
 /turf/simulated/wall,
 /area/tcommsat/entrance)
 "bqg" = (
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bqh" = (
 /obj/machinery/firealarm{
@@ -32031,11 +32009,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bqi" = (
 /obj/machinery/light{
@@ -32050,17 +32024,13 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bqj" = (
 /obj/machinery/porta_turret{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bqk" = (
 /obj/structure/sign/securearea,
@@ -32479,11 +32449,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bqZ" = (
 /obj/structure/window/reinforced,
@@ -33005,27 +32971,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "brT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "brU" = (
 /obj/structure/catwalk,
@@ -33043,14 +33001,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "brW" = (
 /obj/structure/cable/green{
@@ -33068,11 +33020,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "brX" = (
 /obj/item/stack/material/wood{
@@ -33453,20 +33401,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bsK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bsL" = (
 /obj/machinery/door/airlock/hatch{
@@ -33713,7 +33656,7 @@
 /obj/machinery/porta_turret{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "btt" = (
 /obj/structure/cable/green{
@@ -33784,7 +33727,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/computer)
 "btz" = (
 /obj/machinery/airlock_sensor{
@@ -33813,7 +33756,7 @@
 	tag_secure = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/computer)
 "btA" = (
 /obj/machinery/light/small{
@@ -33829,7 +33772,7 @@
 	pixel_x = 0;
 	pixel_y = 28
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/computer)
 "btB" = (
 /turf/simulated/floor/plating,
@@ -34054,17 +33997,6 @@
 "bud" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/powercontrol)
-"bue" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance)
-"buf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance)
 "bug" = (
 /obj/machinery/light,
 /turf/simulated/floor/reinforced,
@@ -34469,7 +34401,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/powercontrol)
 "buY" = (
 /obj/structure/cable{
@@ -34477,7 +34409,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "buZ" = (
 /obj/machinery/light,
@@ -34486,7 +34418,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bva" = (
 /turf/simulated/wall/r_wall,
@@ -35380,7 +35312,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintroom5)
 "bwM" = (
-/obj/machinery/vending/assist,
+/obj/machinery/vending/assist{
+	icon_state = "generic";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintroom5)
 "bwN" = (
@@ -36349,7 +36284,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "byV" = (
 /obj/structure/table/standard,
@@ -37749,7 +37684,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/computer)
 "bBN" = (
 /obj/structure/table/steel,
@@ -37789,7 +37724,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/tcomfoyer)
 "bBQ" = (
 /obj/effect/floor_decal/spline/plain,
@@ -38789,11 +38724,7 @@
 	dir = 4;
 	icon_state = "camera"
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bDV" = (
 /obj/machinery/hologram/holopad,
@@ -38817,11 +38748,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "bDX" = (
 /obj/machinery/hologram/holopad,
@@ -40243,6 +40170,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
+"fxl" = (
+/obj/random/cutout,
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
+"fCu" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/civilian/atrium/lower)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
 	dir = 4
@@ -40260,6 +40201,19 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/borealis2/outdoors/grounds/tower/northeast)
+"glo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/entrance)
+"gwZ" = (
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/aft)
 "gMS" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/tiled/dark,
@@ -40292,23 +40246,22 @@
 	frequency = 1441;
 	pixel_y = 22
 	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
+"hvL" = (
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/fore)
 "hAT" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/east)
 "hEt" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "hJS" = (
 /turf/simulated/floor/tiled/white,
@@ -40418,6 +40371,13 @@
 /obj/structure/sign/atmos/n2,
 /turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
+"iNp" = (
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/central)
 "iRP" = (
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/west)
@@ -40453,6 +40413,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
+"jSK" = (
+/obj/machinery/door/airlock/maintenance/sec{
+	name = "Security Maintenance";
+	req_access = list(63);
+	req_one_access = list(1)
+	},
+/turf/simulated/floor/plating,
+/area/security/range)
 "jWo" = (
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
@@ -40492,6 +40460,10 @@
 /obj/structure/railing,
 /turf/simulated/floor/water/indoors,
 /area/crew_quarters/kitchen/fish_farm)
+"lBZ" = (
+/obj/random/cutout,
+/turf/simulated/floor/plating,
+/area/maintenance/medical_lower)
 "lDK" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -40499,6 +40471,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/lower)
+"lJg" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medical_lower)
 "mbM" = (
 /obj/structure/table/glass,
 /obj/structure/cable/green{
@@ -40565,6 +40543,13 @@
 	},
 /turf/simulated/floor,
 /area/engineering/atmos)
+"nRl" = (
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/fore)
 "nYq" = (
 /obj/structure/sign/poster,
 /turf/simulated/wall/titanium,
@@ -40582,10 +40567,32 @@
 /obj/structure/sign/poster,
 /turf/simulated/wall/titanium,
 /area/borealis2/outdoors/grounds/tower/southwest)
+"ozl" = (
+/obj/machinery/light,
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/civilian/atrium/lower)
 "oEU" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/south)
+"oPS" = (
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
+"oUC" = (
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/sleep/cryo)
 "oVe" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/security,
@@ -40642,6 +40649,10 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/northeast)
+"pPl" = (
+/obj/random/cutout,
+/turf/simulated/floor/plating,
+/area/maintenance/lowfloor3)
 "pRC" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -40676,6 +40687,13 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/mine/explored/lower_rock)
+"qPV" = (
+/obj/machinery/door/airlock/maintenance/sec{
+	name = "Security Maintenance";
+	req_one_access = list(1,18)
+	},
+/turf/simulated/floor/plating,
+/area/security/prison)
 "qWF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40700,6 +40718,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/lower)
+"rhO" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecoms Satellite";
+	req_access = newlist();
+	req_one_access = list(61,52)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/entrance)
+"riO" = (
+/obj/random/cutout,
+/turf/simulated/floor,
+/area/mine/explored/lower_rock)
 "rjR" = (
 /obj/machinery/light/small,
 /obj/structure/table/steel,
@@ -40754,6 +40794,12 @@
 /obj/structure/table/rack/shelf/steel,
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/south)
+"ssJ" = (
+/obj/random/obstruction,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cutout,
+/turf/simulated/floor,
+/area/maintenance/security_lower)
 "szF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40899,6 +40945,10 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/borealis2/outdoors/grounds/tower/east)
+"vQg" = (
+/obj/random/cutout,
+/turf/simulated/floor,
+/area/maintenance/chapel)
 "vZk" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -40942,6 +40992,10 @@
 "xrS" = (
 /turf/simulated/wall/titanium,
 /area/borealis2/outdoors/grounds/tower/southeast)
+"xxt" = (
+/obj/random/cutout,
+/turf/simulated/floor,
+/area/maintenance/atmos_control)
 "xze" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/security,
@@ -40971,6 +41025,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/medical_lower)
+"xMs" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/entrance)
 "ycA" = (
 /obj/structure/sign/poster,
 /turf/simulated/wall/titanium,
@@ -60668,7 +60726,7 @@ aae
 aac
 aac
 adX
-afe
+pPl
 afe
 afe
 afe
@@ -66008,7 +66066,7 @@ agd
 aNg
 aNg
 aOP
-aNg
+aPU
 aPU
 aQN
 aQN
@@ -66260,7 +66318,7 @@ agd
 aNg
 aOo
 aNQ
-aNg
+aPU
 aPU
 aQK
 aQL
@@ -66510,9 +66568,9 @@ ajw
 agw
 agd
 aNg
-aOo
+ssJ
 aNg
-aNg
+aPU
 aPU
 aQL
 aQL
@@ -66764,7 +66822,7 @@ age
 aNO
 aNQ
 aNg
-aNg
+aPU
 aPU
 aQK
 aQL
@@ -67016,9 +67074,9 @@ aOp
 aOq
 aOr
 aNQ
-aNQ
-aPV
-aQM
+aPU
+aPU
+aQL
 aQL
 aSm
 aQL
@@ -67268,7 +67326,7 @@ age
 aNQ
 bhG
 aOQ
-aOs
+aPU
 aPU
 aQK
 boh
@@ -67506,7 +67564,7 @@ aDY
 aAs
 agw
 agw
-agw
+lBZ
 agw
 agw
 aJs
@@ -67524,7 +67582,7 @@ aOR
 aOR
 aQN
 aQN
-aQN
+jSK
 aQN
 aQN
 aVk
@@ -67771,12 +67829,12 @@ aMy
 aNj
 aJt
 bhG
-aOR
+qPV
 aPk
 aPX
 aQO
 aPW
-aQJ
+aQM
 aOR
 aUk
 aVl
@@ -75098,7 +75156,7 @@ bal
 bal
 ber
 bfr
-bal
+xxt
 bgI
 bhz
 bii
@@ -75527,7 +75585,7 @@ abw
 abw
 abw
 abw
-abw
+abx
 aci
 aci
 aci
@@ -75772,7 +75830,7 @@ aaf
 aaq
 aan
 abx
-aid
+ayH
 ayH
 abx
 abw
@@ -75783,7 +75841,7 @@ abx
 aci
 aci
 agw
-agw
+lJg
 agw
 agw
 afi
@@ -75823,7 +75881,7 @@ aFE
 aBe
 aBe
 aIG
-aHW
+aBe
 aBe
 anz
 anC
@@ -76024,13 +76082,13 @@ aaf
 aaq
 aaq
 abx
-axz
+aNR
 aNR
 abx
 abx
 abx
-abw
-aby
+abx
+abx
 abx
 aci
 aci
@@ -76073,9 +76131,9 @@ aBY
 aER
 aCB
 aGe
-bgY
 aCE
 aCE
+oUC
 aIM
 anz
 anD
@@ -76579,7 +76637,7 @@ aCB
 aGg
 aCE
 aCE
-aFI
+aHY
 aIO
 anz
 aom
@@ -78390,7 +78448,7 @@ bkK
 bps
 bps
 bps
-bsL
+rhO
 bps
 bps
 bud
@@ -78896,8 +78954,8 @@ bqh
 bqg
 brT
 bsJ
-bsJ
-bue
+glo
+glo
 buY
 bvJ
 bwB
@@ -79397,12 +79455,12 @@ boe
 bkK
 bps
 bqg
-bqg
+xMs
 brV
 bsK
 bsK
-buf
-buf
+bsK
+bsK
 bvL
 bwD
 bxp
@@ -79827,7 +79885,7 @@ ajz
 ajy
 akF
 aig
-agj
+nRl
 agj
 amK
 ajA
@@ -80095,7 +80153,7 @@ avC
 aww
 axJ
 azc
-aAb
+ozl
 fMr
 aBg
 aBg
@@ -80379,7 +80437,7 @@ aAX
 aCN
 awv
 awv
-ayN
+gwZ
 ayN
 ayN
 imj
@@ -80580,7 +80638,7 @@ agj
 ahD
 agj
 agj
-agj
+hvL
 agj
 akJ
 all
@@ -80615,7 +80673,7 @@ aGQ
 dcc
 aHF
 aKk
-aAc
+fCu
 aLe
 aMk
 aMQ
@@ -81629,7 +81687,7 @@ cBv
 awv
 aCK
 awv
-awv
+iNp
 aAD
 awv
 aHa
@@ -84403,7 +84461,7 @@ aMW
 aNC
 aLp
 aLM
-aPb
+oPS
 aPK
 aQx
 aRf
@@ -85695,7 +85753,7 @@ bls
 bkO
 bkO
 boQ
-bls
+fxl
 bls
 brg
 bls
@@ -89141,7 +89199,7 @@ acN
 aeX
 acB
 adB
-acN
+vQg
 adw
 acB
 ahh
@@ -89242,7 +89300,7 @@ bls
 bls
 bkO
 brg
-bls
+fxl
 bkO
 aan
 aan
@@ -89437,7 +89495,7 @@ aJL
 aeq
 aan
 abq
-acZ
+riO
 aeY
 aNd
 ahi

--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -717,6 +717,9 @@
 /area/hallway/secondary/exit)
 "abI" = (
 /obj/structure/table/standard,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "abJ" = (
@@ -2073,6 +2076,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit_link)
 "aeu" = (
@@ -3982,6 +3988,9 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
+	},
+/obj/machinery/holoposter{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -7023,6 +7032,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "aoh" = (
@@ -7033,13 +7046,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue,
-/obj/machinery/computer/guestpass{
-	dir = 1;
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/docking_lounge)
-"aoi" = (
 /obj/machinery/embedded_controller/radio/docking_port_multi{
 	child_names_txt = "Airlock One;Airlock Two";
 	child_tags_txt = "arrivals_dock_north_airlock;arrivals_dock_south_airlock";
@@ -7049,6 +7055,9 @@
 	pixel_y = -25;
 	req_one_access = list(13)
 	},
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/docking_lounge)
+"aoi" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 8
 	},
@@ -12650,10 +12659,6 @@
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall,
 /area/medical/reception)
-"axG" = (
-/obj/structure/noticeboard/medical,
-/turf/simulated/wall,
-/area/medical/patient_c)
 "axH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15883,10 +15888,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
-"aDw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/snow/snow/snow2/cryogaia,
-/area/borealis2/outdoors/grounds)
 "aDx" = (
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
@@ -16562,7 +16563,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "aEW" = (
-/obj/machinery/vending/nifsoft_shop,
+/obj/machinery/vending/nifsoft_shop{
+	icon_state = "proj";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "aEX" = (
@@ -16855,6 +16859,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/primary/aft)
 "aFz" = (
@@ -17292,6 +17300,7 @@
 /obj/structure/cable{
 	icon_state = "32-4"
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/open,
 /area/maintenance/medbay)
 "aGo" = (
@@ -20321,6 +20330,10 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
 	},
+/obj/structure/noticeboard/blueshield{
+	name = "blueshield notice board";
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/old_tile/blue,
 /area/bridge/blueshield)
 "aMz" = (
@@ -20738,21 +20751,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/maintenance/bridge)
-"aNq" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/maintenance/bridge)
 "aNr" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(52)
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/maintenance/bridge)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/blueshield)
 "aNs" = (
 /obj/structure/table/rack,
 /obj/item/weapon/flame/lighter/zippo/blue,
@@ -22441,6 +22445,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/noticeboard{
+	name = "security notice board";
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
 "aQy" = (
@@ -22489,8 +22497,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "aQE" = (
-/obj/machinery/vending/dinnerware,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/vending/dinnerware{
+	icon_state = "dinnerware";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "aQF" = (
@@ -24989,6 +25000,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/noticeboard{
+	name = "public notice board";
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
@@ -28600,9 +28615,6 @@
 /turf/simulated/floor/tiled/white,
 /area/security/security_aid_station)
 "bbl" = (
-/obj/structure/sign/department/bar{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -30920,6 +30932,10 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "bff" = (
@@ -32954,7 +32970,7 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/water_cooler/full,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/workshop)
 "biJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35355,7 +35371,7 @@
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/box/cups,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/workshop)
 "bmS" = (
 /obj/structure/cable/green{
@@ -38306,6 +38322,10 @@
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 8
 	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "bsj" = (
@@ -39249,7 +39269,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/workshop)
 "btX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -39348,6 +39368,11 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering Workshop East";
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
@@ -42461,10 +42486,6 @@
 	pixel_y = 4
 	},
 /obj/item/device/radio/off,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
@@ -43900,6 +43921,10 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
+	},
+/obj/structure/noticeboard{
+	name = "engineering notice board";
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -50549,6 +50574,9 @@
 /area/crew_quarters/locker/locker_toilet)
 "bMO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/locker/locker_toilet)
 "bMP" = (
@@ -62899,6 +62927,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "ckD" = (
@@ -63135,19 +63167,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/coffee,
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	frequency = 1475;
-	icon_state = "intercom";
-	listening = 1;
-	name = "Station Intercom (Security)";
-	pixel_x = 0;
-	pixel_y = -21
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
+	},
+/obj/machinery/vending/coffee{
+	icon_state = "coffee";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
@@ -63443,6 +63468,24 @@
 "cZS" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
+"dar" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "dcv" = (
 /obj/machinery/camera/network/outside{
 	c_tag = "Solar Array Shed - Exterior"
@@ -63547,6 +63590,12 @@
 "dNQ" = (
 /turf/simulated/wall/titanium,
 /area/borealis2/outdoors/grounds/wall)
+"dQf" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/hallway/secondary/entry/docking_lounge)
 "dVw" = (
 /turf/simulated/floor/tiled/steel,
 /area/maintenance/medbay)
@@ -63591,6 +63640,10 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/snow/snow/cryogaia/covered,
 /area/borealis2/outdoors/exterior/explore3)
+"eez" = (
+/obj/random/cutout,
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "eeB" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -64156,6 +64209,16 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	frequency = 1475;
+	icon_state = "intercom";
+	listening = 1;
+	name = "Station Intercom (Security)";
+	pixel_x = 0;
+	pixel_y = -21
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
 "gcR" = (
@@ -64403,6 +64466,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security)
+"hkx" = (
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/obj/machinery/camera/motion/command{
+	c_tag = "Blueshield Reserve";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/blueshield)
 "hkP" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "2-8"
@@ -65178,6 +65252,10 @@
 	},
 /turf/simulated/floor/outdoors/snow/snow/snow2/cryogaia,
 /area/borealis2/outdoors/grounds)
+"kka" = (
+/obj/random/cutout,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge)
 "kki" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "2-8"
@@ -65199,6 +65277,16 @@
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/power)
+"kkC" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 8;
+	icon_state = "wooden_chair_wings"
+	},
+/obj/structure/sign/double/barsign{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "kmr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -65355,6 +65443,25 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/security)
+"kIU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "kJo" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/plating/snow/plating/cryogaia,
@@ -66388,6 +66495,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"oGh" = (
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_one)
 "oHa" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -66445,6 +66558,7 @@
 /obj/structure/disposalpipe/up{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "oQv" = (
@@ -66516,6 +66630,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
+"paz" = (
+/obj/random/cutout,
+/turf/simulated/floor,
+/area/engineering/drone_fabrication)
 "paU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -66562,6 +66680,10 @@
 "pih" = (
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay)
+"pii" = (
+/obj/random/cutout,
+/turf/simulated/floor/plating,
+/area/lawoffice)
 "piA" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
@@ -67033,7 +67155,10 @@
 /obj/effect/floor_decal/corner/pink/full{
 	dir = 4
 	},
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical{
+	icon_state = "med";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "rrd" = (
@@ -67111,6 +67236,13 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/east)
+"rGh" = (
+/obj/machinery/door/airlock/highsecurity/red{
+	name = "Blueshield Special Reserve";
+	req_one_access = list(52)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/blueshield)
 "rKg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67338,6 +67470,13 @@
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
+"sAw" = (
+/obj/structure/noticeboard{
+	name = "bridge notice board";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "sAF" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -68138,6 +68277,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/borealis2/outdoors/grounds/traderpad)
+"vfS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/civilian/atrium/central)
 "vhi" = (
 /turf/simulated/floor/outdoors/ice,
 /area/borealis2/outdoors/exterior)
@@ -68180,6 +68334,13 @@
 	},
 /turf/simulated/wall,
 /area/medical/psych)
+"vpw" = (
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "vrr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -68263,6 +68424,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
+"vFD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/structure/noticeboard{
+	name = "security notice board";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/steel,
+/area/security/hallway)
 "vFI" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/techmaint,
@@ -68519,6 +68702,13 @@
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/power)
+"wrG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "wss" = (
 /obj/structure/grille,
 /obj/structure/cable/green{
@@ -68793,6 +68983,15 @@
 /obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
+"xfy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge)
 "xjh" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/green{
@@ -86258,7 +86457,7 @@ aag
 aag
 aag
 aag
-aDw
+aag
 aag
 aag
 aag
@@ -86510,7 +86709,7 @@ aag
 aag
 aag
 aag
-aDw
+aag
 aag
 aag
 aag
@@ -86762,7 +86961,7 @@ aag
 aag
 aag
 aag
-aDw
+aag
 aag
 aag
 aag
@@ -87014,8 +87213,8 @@ aag
 aag
 aag
 aag
-aDw
-aDw
+aag
+aag
 aag
 aag
 aHP
@@ -87265,9 +87464,9 @@ aag
 aag
 aag
 aag
-aDw
-aDw
-aDw
+aag
+aag
+aag
 aag
 aag
 aHP
@@ -87775,9 +87974,9 @@ aag
 aag
 aag
 aHP
-aIB
-aIB
 aKp
+aIB
+aIB
 aHP
 dcv
 abk
@@ -95320,7 +95519,7 @@ aag
 aag
 aag
 akb
-akA
+eez
 akA
 akA
 akA
@@ -99353,7 +99552,7 @@ ckj
 avG
 avR
 avG
-axG
+atC
 cir
 ayo
 azc
@@ -101891,7 +102090,7 @@ aHj
 aIZ
 aJP
 aHp
-bhP
+pii
 aMW
 aNC
 aOx
@@ -101905,7 +102104,7 @@ aYO
 bdU
 bhs
 bar
-bfv
+vFD
 bmQ
 bnd
 bne
@@ -106220,7 +106419,7 @@ bID
 bJM
 bKW
 bMn
-bMn
+paz
 bKW
 bJM
 bID
@@ -106439,7 +106638,7 @@ aSZ
 aUU
 aWg
 aXg
-aXg
+kkC
 aTL
 aQt
 aZf
@@ -106691,7 +106890,7 @@ aRG
 aUS
 aFu
 aRG
-aNH
+aRG
 aRI
 bcZ
 bcZ
@@ -107165,7 +107364,7 @@ aoT
 auM
 ckt
 aoT
-apM
+oGh
 apM
 azy
 aHy
@@ -107174,7 +107373,7 @@ kBA
 aCe
 aBY
 aAk
-aAk
+vfS
 aAk
 aFO
 aAk
@@ -107660,7 +107859,7 @@ ajv
 amB
 ano
 aoi
-agk
+dQf
 apM
 apM
 arq
@@ -108963,7 +109162,7 @@ aYn
 dKN
 dKN
 bbP
-bde
+vpw
 bde
 bfx
 bgK
@@ -111466,7 +111665,7 @@ aDl
 aFV
 aFV
 aKK
-aLB
+sAw
 aMp
 aNi
 aNR
@@ -111955,7 +112154,7 @@ atl
 atl
 atl
 atl
-ayV
+kka
 awY
 axZ
 aBo
@@ -112240,7 +112439,7 @@ aZt
 baM
 bbY
 aYu
-bep
+wrG
 bfH
 cia
 bgT
@@ -113229,7 +113428,7 @@ aHI
 aIj
 aJw
 aAu
-ayU
+xfy
 aLE
 aMw
 aNo
@@ -114005,7 +114204,7 @@ aHu
 aHu
 atI
 beo
-bfD
+kIU
 aYz
 bie
 bjB
@@ -114238,8 +114437,8 @@ aIn
 gQF
 aAu
 ayU
-avg
-aNq
+aLG
+aLG
 aNY
 aOY
 aRV
@@ -114490,7 +114689,7 @@ aBD
 sdy
 aAu
 lAq
-avg
+aLG
 aNr
 aNY
 aOZ
@@ -114742,8 +114941,8 @@ aIp
 aAu
 aAu
 ayU
-avg
-avg
+aLG
+hkx
 aNY
 aPa
 aRV
@@ -114995,7 +115194,7 @@ aAu
 avg
 aKQ
 aLG
-aLG
+rGh
 aLG
 aLG
 aPb
@@ -117298,7 +117497,7 @@ bwl
 bxn
 byB
 bsl
-bBe
+dar
 bCs
 beo
 beq

--- a/maps/yw/cryogaia-06-upper.dmm
+++ b/maps/yw/cryogaia-06-upper.dmm
@@ -581,7 +581,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "aeZ" = (
 /obj/structure/table/rack/shelf/steel,
@@ -597,7 +597,7 @@
 	name = "plastic table frame"
 	},
 /obj/random/maintenance/medical,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "afT" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner/blue,
@@ -648,7 +648,7 @@
 	pixel_x = 21;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "amc" = (
 /obj/structure/catwalk,
@@ -689,7 +689,7 @@
 	icon_state = "cigs";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "aqW" = (
 /obj/structure/cable{
@@ -763,7 +763,7 @@
 	layer = 3.3;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "aAM" = (
 /obj/structure/cable/green{
@@ -779,6 +779,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
+"aBj" = (
+/obj/structure/railing/grey{
+	dir = 1;
+	flags = null
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/upper)
 "aBo" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -1066,6 +1073,11 @@
 /obj/structure/railing/grey,
 /turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/south)
+"bnO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "bnZ" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/paleblue/diagonal{
@@ -1163,7 +1175,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "buV" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -1173,7 +1185,7 @@
 	icon_state = "coffee";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "buZ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
@@ -1432,7 +1444,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "bYL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1821,7 +1833,7 @@
 /area/civilian/atrium/upper)
 "dcB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "dfC" = (
 /obj/structure/bed/chair/wood{
@@ -1843,7 +1855,7 @@
 	icon_state = "fitness";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "dhP" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
@@ -2264,15 +2276,24 @@
 /area/borealis2/outdoors/grounds/tower/west)
 "efV" = (
 /obj/structure/railing,
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
 /obj/machinery/light/no_nightshift{
 	icon_state = "tube1";
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
+"egN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "ehJ" = (
 /obj/structure/railing{
 	dir = 4;
@@ -2437,7 +2458,7 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "eKY" = (
 /obj/machinery/light{
@@ -2468,7 +2489,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "eQZ" = (
 /turf/simulated/wall,
@@ -2594,6 +2615,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/chapel/monastery/upper)
+"flA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "fmx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -2840,6 +2867,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbayupper)
+"gcN" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/turf/simulated/floor/plating,
+/area/maintenance/security_tower)
 "gdt" = (
 /obj/structure/railing/grey{
 	icon_state = "grey_railing0";
@@ -2869,8 +2902,13 @@
 	icon_state = "tube1";
 	pixel_x = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
+"ghz" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/breakroom)
 "giD" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -2879,7 +2917,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "gjI" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -2989,7 +3027,7 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "gvx" = (
 /obj/structure/railing{
@@ -3005,7 +3043,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "gyY" = (
 /obj/structure/cable/green{
@@ -3049,7 +3087,7 @@
 "gFG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "gHl" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
@@ -3224,6 +3262,21 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/walkway/exploration)
+"hpL" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/microwave,
+/obj/item/device/geiger/wall{
+	dir = 8;
+	pixel_x = 30
+	},
+/obj/machinery/light/no_nightshift{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "hqr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -3285,6 +3338,7 @@
 	dir = 6
 	},
 /obj/random/medical/lite,
+/obj/random/tetheraid,
 /turf/simulated/floor/tiled/white,
 /area/cryogaia/station/medical/upper)
 "hAJ" = (
@@ -3293,6 +3347,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
+"hAV" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28;
+	req_access = newlist();
+	req_one_access = list(51)
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "hCZ" = (
 /turf/simulated/wall,
 /area/civilian/atrium/upper)
@@ -3303,7 +3371,7 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "hFf" = (
 /turf/simulated/open,
@@ -3399,7 +3467,7 @@
 /obj/machinery/door/airlock/maintenance/sec,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/maintenance/security_tower)
+/area/security/watchtower)
 "hRM" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -3418,6 +3486,26 @@
 /obj/item/device/instrument/recorder,
 /turf/simulated/floor/wood,
 /area/chapel/monastery/music)
+"hTY" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/device/radio/intercom/department/security{
+	dir = 8;
+	icon_state = "secintercom";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/no_nightshift{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "hUR" = (
 /obj/structure/railing/grey{
 	icon_state = "grey_railing0";
@@ -3668,6 +3756,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
+"iCu" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/storage/box/donkpockets,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Break Room";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_x = 30
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "iCB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -3817,7 +3924,7 @@
 	pixel_x = 28;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "jeP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3912,6 +4019,9 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
+"jyR" = (
+/turf/simulated/wall/r_wall,
+/area/security/breakroom)
 "jzU" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
@@ -3967,7 +4077,7 @@
 /area/cryogaia/station/hallway/primary/upper)
 "jKN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "jLk" = (
 /obj/structure/cable/green{
@@ -4059,6 +4169,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/miningdock)
+"jYb" = (
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/cryogaia/station/hallway/primary/upper)
 "jZh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4161,7 +4278,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "kpg" = (
 /obj/machinery/vending/coffee{
@@ -4279,9 +4396,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
-"kJK" = (
-/turf/simulated/wall,
-/area/maintenance/security_tower)
 "kKk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -4303,7 +4417,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "kPV" = (
 /obj/machinery/light/small{
@@ -4326,7 +4440,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "kUh" = (
 /obj/effect/floor_decal/corner/paleblue/full{
@@ -4354,6 +4468,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
+"kVN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/vending/coffee{
+	icon_state = "coffee";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "kZT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4427,7 +4553,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "lkz" = (
 /obj/structure/disposalpipe/segment{
@@ -4481,6 +4607,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
+"lut" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "lvE" = (
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "Monastary_Upper_NW_Exit";
@@ -4495,6 +4629,12 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating/snow/plating,
 /area/chapel/monastery/upper)
+"lvH" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "lwd" = (
 /turf/simulated/open,
 /area/cryogaia/station/explorer_upper)
@@ -4858,9 +4998,6 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
 "mzQ" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
 /obj/item/device/radio/intercom/department/security{
 	dir = 4;
 	icon_state = "secintercom";
@@ -4993,6 +5130,13 @@
 /area/civilian/atrium/upper)
 "mWF" = (
 /turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/walkway/exploration)
+"mYz" = (
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	flags = null
+	},
+/turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/walkway/exploration)
 "mYC" = (
 /obj/machinery/light{
@@ -5134,11 +5278,18 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "nny" = (
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/hallway/primary/upper)
+"noQ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/deck/cards,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "nqi" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
@@ -5153,7 +5304,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "nrN" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "nsl" = (
 /obj/structure/cable{
@@ -5286,6 +5437,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/chapel/monastery/upper)
+"nHt" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "nIj" = (
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/upper)
@@ -5307,6 +5464,10 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/belter)
+"nOw" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "nPp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5378,7 +5539,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "nYu" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
@@ -5661,6 +5822,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/miningdock)
+"oBV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "oCb" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -5695,6 +5862,17 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/atrium/upper)
+"oCZ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/weapon/storage/box/cups,
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "oDz" = (
 /obj/structure/ladder,
 /turf/simulated/floor/plating/snow/plating/cryogaia,
@@ -5836,6 +6014,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
+"oUY" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/noticeboard/medical{
+	dir = 4;
+	name = "medical notice board";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbayupper)
 "oWp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5920,7 +6110,7 @@
 /obj/machinery/camera/network/medbay{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "phE" = (
 /obj/effect/floor_decal/corner/brown/full,
@@ -5961,6 +6151,9 @@
 	},
 /turf/simulated/open,
 /area/civilian/atrium/upper)
+"psk" = (
+/turf/simulated/floor/plating,
+/area/maintenance/security_tower)
 "puK" = (
 /obj/structure/railing/grey{
 	icon_state = "grey_railing0";
@@ -6156,6 +6349,13 @@
 /obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningdock)
+"qgu" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "qgB" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/glass,
@@ -6198,6 +6398,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/hallway/primary/upper)
 "qlq" = (
@@ -6214,13 +6417,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southeast)
 "qmn" = (
-/obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
+	},
+/obj/machinery/vending/snack{
+	icon_state = "snack";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
@@ -6240,14 +6446,11 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/effect/floor_decal/corner/red/full,
+/obj/item/device/geiger/wall{
+	dir = 4;
+	pixel_x = -30
 	},
-/obj/structure/closet,
-/obj/random/maintenance/security,
-/obj/random/maintenance/security,
-/obj/random/maintenance/security,
-/obj/random/maintenance/security,
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
 "qmJ" = (
@@ -6440,7 +6643,7 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/large,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "qzN" = (
 /turf/simulated/wall,
@@ -6522,6 +6725,13 @@
 	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/upper)
+"qGH" = (
+/obj/structure/closet,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/turf/simulated/floor/plating,
+/area/maintenance/security_tower)
 "qGO" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
@@ -6665,6 +6875,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbayupper)
+"rds" = (
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/cryogaia/station/hallway/primary/upper)
 "rdP" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
@@ -6739,12 +6956,6 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
-"rnY" = (
-/obj/effect/floor_decal/corner/red/full{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/watchtower)
 "rpj" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
@@ -6789,7 +7000,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "rDD" = (
 /turf/simulated/shuttle/floor/white/cryogaia,
@@ -7066,7 +7277,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "syH" = (
 /obj/structure/cable/green{
@@ -7390,7 +7601,7 @@
 	name = "plastic table frame"
 	},
 /obj/item/weapon/material/ashtray/plastic,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "tgz" = (
 /obj/structure/bookcase/manuals/medical,
@@ -7409,7 +7620,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "tjQ" = (
 /obj/effect/floor_decal/corner/brown{
@@ -7554,6 +7765,22 @@
 	},
 /turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/west)
+"tEB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
+"tGf" = (
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_tower)
 "tKT" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
@@ -7705,6 +7932,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/cryogaia/station/medical/upper)
+"tWN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "tXH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
@@ -7721,6 +7955,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/constructionsite/medical/upper)
+"tYd" = (
+/obj/machinery/door/airlock/maintenance/sec,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/security/breakroom)
 "tZb" = (
 /turf/simulated/floor/plating,
 /area/cryogaia/station/hallway/primary/upper)
@@ -7827,6 +8073,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbayupper)
+"ure" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "uro" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -7859,6 +8112,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
+"uzO" = (
+/obj/machinery/light/no_nightshift{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/watchtower)
 "uAo" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey,
@@ -8013,6 +8273,7 @@
 	c_tag = "Medical Loft";
 	dir = 1
 	},
+/obj/random/tetheraid,
 /turf/simulated/floor/tiled/white,
 /area/cryogaia/station/medical/upper)
 "vdm" = (
@@ -8108,6 +8369,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/constructionsite/cryogaia/upper)
+"vrU" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Breakroom"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/security/breakroom)
 "vtA" = (
 /turf/simulated/floor/plating,
 /area/maintenance/medical_upper)
@@ -8283,6 +8551,13 @@
 	},
 /turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
+"vTQ" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Breakroom"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/security/watchtower)
 "vTU" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
@@ -8311,6 +8586,13 @@
 	},
 /turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/south)
+"vZc" = (
+/obj/structure/railing/grey{
+	dir = 4;
+	flags = null
+	},
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds/upper)
 "wdS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8425,7 +8707,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "wte" = (
 /turf/simulated/wall/titanium,
@@ -8538,15 +8820,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_tower)
@@ -8576,6 +8860,12 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
+"wNY" = (
+/obj/structure/closet,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/turf/simulated/floor/plating,
+/area/maintenance/security_tower)
 "wPJ" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey,
@@ -8712,6 +9002,13 @@
 /obj/effect/floor_decal/corner/purple,
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_upper)
+"xkg" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "xlt" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/glass,
@@ -8878,7 +9175,7 @@
 	icon_state = "Soda_Machine";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "xFu" = (
 /obj/structure/bed/chair,
@@ -8900,6 +9197,9 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/hallway/primary/upper)
+"xMy" = (
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "xOp" = (
 /obj/effect/floor_decal/corner/white/full{
 	icon_state = "corner_white_full";
@@ -37361,13 +37661,13 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-tlZ
+jyR
+ghz
+ghz
+ghz
+ghz
+jyR
+jyR
 ovG
 tlZ
 tlZ
@@ -37613,13 +37913,13 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-tlZ
+ghz
+lvH
+lvH
+egN
+bnO
+hTY
+tYd
 wFQ
 pmD
 pmD
@@ -37865,18 +38165,18 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-tlZ
-tlZ
-tlZ
-kJK
+ghz
+noQ
+qgu
+tEB
+xMy
+kVN
+jyR
+tGf
+gcN
+aDf
 hRu
-kJK
+aDf
 aDf
 cnY
 ieg
@@ -38117,15 +38417,15 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
+ghz
+nHt
+nHt
+flA
+xMy
+hAV
+jyR
+psk
+psk
 aDf
 qmJ
 qmr
@@ -38369,15 +38669,15 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
+ghz
+xMy
+xMy
+flA
+xMy
+xkg
+jyR
+wNY
+qGH
 aDf
 sWj
 xqc
@@ -38621,15 +38921,15 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
+ghz
+xMy
+oBV
+tWN
+xMy
+lut
+jyR
+qUI
+qUI
 aDf
 efV
 xqc
@@ -38873,17 +39173,17 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-aDf
-rnY
+jyR
+hpL
+iCu
+oCZ
+nOw
+ure
+vrU
+uzO
+jjc
+vTQ
+jjc
 mzQ
 lbF
 jjc
@@ -39125,15 +39425,15 @@ eFr
 eFr
 eFr
 eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
-eFr
+jyR
+jyR
+jyR
+jyR
+jyR
+jyR
+jyR
+qUI
+qUI
 aDf
 aDf
 aDf
@@ -39349,7 +39649,7 @@ kwL
 nZu
 oxg
 iXv
-mEQ
+oUY
 vfZ
 itq
 iXv
@@ -44208,7 +44508,7 @@ eFr
 eFr
 eFr
 aZL
-aZL
+vZc
 fbI
 eFr
 eFr
@@ -44461,7 +44761,7 @@ aZL
 dXx
 aaf
 aaf
-xAZ
+aBj
 eFr
 eFr
 eFr
@@ -54284,7 +54584,7 @@ nny
 nny
 nny
 oLF
-nny
+rds
 nny
 nny
 nny
@@ -56556,7 +56856,7 @@ pQE
 pQE
 wYp
 nny
-nny
+jYb
 erL
 eFr
 eFr
@@ -59330,7 +59630,7 @@ erL
 qoj
 xFf
 qaR
-aZL
+vZc
 aZL
 aZL
 dXx
@@ -59581,7 +59881,7 @@ aaf
 aaf
 gRM
 pBg
-vVm
+mYz
 aaf
 aaf
 aaf


### PR DESCRIPTION
Oh look it's that time again!
- restored the big bar sign, so that's a thing I guess.
- pǝʇɐʇoꓤ a few more vendors down on the sublevel. you thought you were safe? think again, fools!!
- added a security breakroom to the upper floor, opposite the watchtower, to replace the one that got removed. bonus: coffee machine. rejoice!
- central says ad revenues are down, so holoposters have been installed throughout public areas in an attempt to fix this issue.
- as noticeboards are now supposedly persistent, several have been added to various locations. YW: now with 100% more passive-aggressive post-it notes. /s ~~or is it~~
- good news: Blueshield now has a Special Reserve armory for when shit is hitting the fan. bad news: Central couldn't budget any equipment for it yet. it works just like the Bridge Holdout & Red Tactical, but CDs who try to raid it will be both disappointed and also like, ***mega-fired***. so don't be That Guy.
- added Mk7 ERT-J suits to the janitorial section of the emergency response team deployment sector, along with an extra suit of M/E/S types.
- fix #856 : removes offending geiger entirely, as the cryopod room is shielded just like maint and the public teleporters.
- fix #902 : virgo added a new access level, but also the xenobotany doors were using req_access (ALL/AND), not req_one_access (ANY/OR). door access levels have been updated accordingly.