### PR TITLE
Fix #991

### DIFF
--- a/maps/yw/cryogaia-04-maintenance.dmm
+++ b/maps/yw/cryogaia-04-maintenance.dmm
@@ -37960,9 +37960,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "wKr" = (
@@ -61030,7 +61027,7 @@ whU
 whU
 liE
 eNq
-mwy
+whU
 whU
 whU
 whU
@@ -61192,8 +61189,8 @@ whU
 whU
 liE
 eNq
-mwy
-mwy
+whU
+whU
 eNq
 whU
 eNq

--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -401,17 +401,11 @@
 /turf/simulated/wall/r_lead,
 /area/engineering/engine_room)
 "ahF" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/item/device/geiger/wall{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/southeast)
+/area/borealis2/outdoors/grounds/tower/west)
 "ahR" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -4333,6 +4327,10 @@
 	dir = 4;
 	icon_state = "camera"
 	},
+/obj/structure/sign/warning/radioactive{
+	name = "\improper OUTPOST RADIATION PROOF";
+	pixel_x = -30
+	},
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds)
 "bKi" = (
@@ -5036,13 +5034,11 @@
 /turf/simulated/floor,
 /area/storage/auxillary)
 "bWv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/snow/floor/edges3{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/west)
+/turf/simulated/floor/plating/snow/plating/cryogaia,
+/area/borealis2/outdoors/grounds)
 "bWx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -8220,6 +8216,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
+"dde" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/borealis2/outdoors/grounds/tower/southeast)
 "ddl" = (
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
@@ -9726,15 +9734,6 @@
 	dir = 8;
 	icon_state = "grey_railing0"
 	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "dLb" = (
@@ -10092,6 +10091,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/east)
@@ -10932,10 +10935,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass_external/freezable{
-	req_one_access = list()
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/plating/snow/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "eeZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11961,10 +11964,6 @@
 "eAJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
 	},
 /turf/simulated/wall/titanium,
 /area/borealis2/outdoors/grounds/tower/east)
@@ -18511,12 +18510,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/southeast)
+/area/borealis2/outdoors/grounds/tower/east)
 "gZI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -23512,6 +23507,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"jcM" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/techmaint,
+/area/borealis2/outdoors/grounds/checkpoint)
 "jde" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 1;
@@ -26744,6 +26748,13 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
+"koI" = (
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/borealis2/outdoors/grounds/tower/southeast)
 "koX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31943,12 +31954,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "mrb" = (
 /obj/item/weapon/stool/padded,
@@ -36854,8 +36860,11 @@
 /turf/simulated/floor/wood,
 /area/chapel/monastery)
 "ocv" = (
-/turf/simulated/wall/titanium,
-/area/borealis2/outdoors/grounds)
+/obj/machinery/door/airlock/glass_external/freezable{
+	req_one_access = list()
+	},
+/turf/simulated/floor/plating/snow/plating,
+/area/borealis2/outdoors/grounds/tower/southwest)
 "ocM" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -42955,6 +42964,7 @@
 	dir = 4;
 	icon_state = "grey_railing0"
 	},
+/obj/machinery/space_heater,
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southeast)
 "qvn" = (
@@ -54490,13 +54500,17 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/workshop)
 "vgU" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/south)
+/area/borealis2/outdoors/grounds/tower/southwest)
 "vgX" = (
 /obj/structure/table/standard,
 /obj/item/device/text_to_speech,
@@ -58323,12 +58337,13 @@
 "wDN" = (
 /obj/structure/cable/green{
 	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
@@ -59774,6 +59789,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"xhg" = (
+/obj/item/device/geiger/wall{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/borealis2/outdoors/grounds/tower/south)
 "xhz" = (
 /obj/structure/closet{
 	name = "materials"
@@ -61634,7 +61656,15 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "xTr" = (
-/obj/machinery/space_heater,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southeast)
 "xTH" = (
@@ -64232,7 +64262,7 @@ neC
 phW
 iSE
 iSE
-cco
+iSE
 iSE
 liC
 iSE
@@ -64273,11 +64303,11 @@ doR
 doR
 doR
 doR
-ocv
+doR
 eHU
 nCX
 fxq
-hzN
+fxq
 iSH
 eHU
 dAA
@@ -64331,7 +64361,7 @@ dAA
 dAA
 dAA
 cao
-tdG
+ahF
 tdG
 tdG
 eUH
@@ -64387,8 +64417,8 @@ dAA
 dAA
 dAA
 phW
-phW
-phW
+vgU
+dKN
 dKN
 gcy
 phW
@@ -64435,7 +64465,7 @@ doR
 doR
 doR
 doR
-ocv
+doR
 eHU
 gtN
 hzN
@@ -64495,7 +64525,7 @@ vDp
 hXZ
 kTu
 sXa
-bWv
+sXa
 jBD
 hXZ
 vDp
@@ -64549,9 +64579,9 @@ vDp
 vDp
 vDp
 vyK
-vyK
-mra
 wDN
+mra
+neC
 tES
 phW
 iSE
@@ -64710,8 +64740,8 @@ rQa
 fCC
 fCC
 fCC
-fCC
-fCC
+ocv
+neC
 eey
 yig
 jrI
@@ -64872,8 +64902,8 @@ lta
 uDf
 uDf
 uDf
-uDf
-uDf
+phW
+phW
 wWc
 phW
 phW
@@ -64982,7 +65012,7 @@ uDf
 uDf
 uDf
 uDf
-uDf
+lta
 uDf
 uDf
 uDf
@@ -65041,7 +65071,7 @@ dAA
 iSE
 iSE
 iSE
-sNi
+iSE
 iSE
 iSE
 liC
@@ -65144,7 +65174,7 @@ uDf
 uDf
 uDf
 uDf
-uDf
+lta
 uDf
 uDf
 uDf
@@ -65306,7 +65336,7 @@ uDf
 uDf
 uDf
 uDf
-uDf
+lta
 uDf
 uDf
 uDf
@@ -65468,7 +65498,7 @@ eku
 eku
 eku
 eku
-eku
+bWv
 eku
 eku
 eku
@@ -66173,7 +66203,7 @@ uDf
 owQ
 dAA
 iSE
-sNi
+iSE
 iSE
 iSE
 iSE
@@ -69252,7 +69282,7 @@ owQ
 dAA
 iSE
 iSE
-gfD
+iSE
 iSE
 iSE
 iSE
@@ -71841,7 +71871,7 @@ uHV
 crf
 crf
 xlG
-nmi
+xhg
 bsA
 crf
 kGU
@@ -72164,7 +72194,7 @@ wBx
 xBe
 crf
 nmi
-vgU
+vRW
 nmi
 lHb
 crf
@@ -74760,7 +74790,7 @@ owQ
 dAA
 iSE
 iSE
-gfD
+iSE
 iSE
 iSE
 iSE
@@ -76541,7 +76571,7 @@ uDf
 owQ
 dAA
 iSE
-sNi
+iSE
 iSE
 iSE
 iSE
@@ -79458,7 +79488,7 @@ owQ
 dAA
 iSE
 iSE
-gfD
+iSE
 iSE
 iSE
 gfD
@@ -80430,7 +80460,7 @@ owQ
 dAA
 iSE
 iSE
-gfD
+iSE
 iSE
 iSE
 iSE
@@ -83990,9 +84020,9 @@ uDf
 nhY
 iPs
 vRw
-vtF
+jcM
 pgP
-pgP
+gBV
 iUT
 iPs
 faB
@@ -86151,7 +86181,7 @@ uDf
 uDf
 uDf
 uDf
-gGS
+uDf
 uDf
 uDf
 uDf
@@ -86226,6 +86256,7 @@ gGb
 pze
 eAJ
 pze
+pze
 uDf
 uDf
 uDf
@@ -86255,7 +86286,6 @@ uDf
 uDf
 uDf
 uDf
-sAw
 sAw
 nIT
 qqp
@@ -86388,6 +86418,7 @@ acu
 acu
 kAy
 pze
+pze
 uDf
 uDf
 uDf
@@ -86418,8 +86449,7 @@ uDf
 uDf
 uDf
 sAw
-ahF
-roT
+xTr
 kaJ
 rjf
 bXR
@@ -86457,7 +86487,7 @@ bfc
 iSE
 rNL
 gKK
-gKK
+udq
 gKK
 egS
 xHR
@@ -86549,39 +86579,39 @@ tVh
 qpy
 dRv
 xvS
-tVh
-tVh
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
-vDp
 gZo
-roT
+tVh
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+vDp
+lPH
+dde
 mOE
 roT
 qnX
@@ -86742,9 +86772,9 @@ dAA
 dAA
 dAA
 dAA
+sAw
 ncl
-ncl
-ncl
+koI
 qva
 bfi
 sAw
@@ -86903,8 +86933,8 @@ iSE
 iSE
 iSE
 iSE
+iSE
 sAw
-xTr
 nGa
 ncl
 koB
@@ -87040,7 +87070,6 @@ pze
 iSE
 gdA
 xEE
-kXB
 xEE
 xEE
 xEE
@@ -87052,7 +87081,8 @@ xEE
 xEE
 xEE
 xEE
-kXB
+xEE
+xEE
 xEE
 xEE
 xEE
@@ -87065,7 +87095,7 @@ xEE
 xEE
 nlv
 iSE
-sAw
+iSE
 sAw
 sAw
 sAw
@@ -87178,7 +87208,7 @@ vaU
 vaU
 vaU
 vaU
-dkI
+vaU
 vaU
 vaU
 vaU
@@ -87361,7 +87391,7 @@ xEE
 xEE
 xEE
 xEE
-kXB
+xEE
 vaU
 vaU
 vaU
@@ -87393,7 +87423,7 @@ xEE
 xEE
 xEE
 xEE
-kXB
+xEE
 xEE
 xEE
 oET
@@ -87426,7 +87456,7 @@ vaU
 vaU
 vaU
 vaU
-dkI
+vaU
 vaU
 vaU
 vaU

--- a/maps/yw/cryogaia-06-upper.dmm
+++ b/maps/yw/cryogaia-06-upper.dmm
@@ -154,8 +154,9 @@
 /area/shuttle/excursion)
 "as" = (
 /obj/structure/catwalk,
+/obj/machinery/light/spot/no_nightshift,
 /turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/southwest)
+/area/borealis2/outdoors/grounds/tower/northwest)
 "at" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -465,12 +466,8 @@
 	dir = 8;
 	icon_state = "grey_railing0"
 	},
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
 /turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/northwest)
+/area/borealis2/outdoors/exterior/upper)
 "bg" = (
 /obj/machinery/light{
 	dir = 8
@@ -605,12 +602,8 @@
 /area/maintenance/auxsolarport)
 "bv" = (
 /obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/turf/simulated/open/cryogaia,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "bw" = (
 /obj/machinery/door/firedoor/glass,
@@ -1494,10 +1487,6 @@
 /turf/simulated/floor/wood,
 /area/chapel/monastery/music)
 "dr" = (
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
 /obj/structure/railing/grey{
 	dir = 4;
 	icon_state = "grey_railing0"
@@ -2736,12 +2725,9 @@
 /turf/simulated/wall/rshull,
 /area/shuttle/excursion)
 "fZ" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/snow/plating/cryogaia,
-/area/borealis2/outdoors/grounds/walkway)
+/area/borealis2/outdoors/grounds/tower/northwest)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -4580,13 +4566,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbayskybridge)
 "jw" = (
-/obj/machinery/space_heater,
-/obj/machinery/firealarm{
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
 	dir = 1;
-	pixel_x = 6;
-	pixel_y = -24
+	icon_state = "grey_railing0"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/light/spot/no_nightshift,
+/turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "jx" = (
 /turf/simulated/wall/r_wall,
@@ -4838,13 +4824,17 @@
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_entrance)
 "jW" = (
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
 /obj/structure/railing/grey{
 	dir = 1;
 	icon_state = "grey_railing0"
 	},
-/obj/structure/catwalk,
 /turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/southwest)
+/area/borealis2/outdoors/grounds/tower/northwest)
 "jX" = (
 /obj/structure/closet/secure_closet/personal/volunteer,
 /obj/effect/floor_decal/corner_oldtile/gray{
@@ -5466,13 +5456,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medical_upper)
 "lm" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/light/spot/no_nightshift,
-/turf/simulated/open/cryogaia,
+/obj/item/device/geiger/wall{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "ln" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
@@ -5859,12 +5850,13 @@
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_entrance)
 "mb" = (
-/obj/item/device/geiger/wall{
-	dir = 8;
-	pixel_x = 30
+/obj/structure/table/steel,
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/southwest)
+/area/borealis2/outdoors/grounds/tower/northwest)
 "mc" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/yellow,
@@ -6022,9 +6014,19 @@
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/explorer_meeting)
 "mv" = (
-/obj/structure/catwalk,
-/turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/southeast)
+/obj/machinery/light,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Common Channel";
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/borealis2/outdoors/grounds/tower/northwest)
 "mw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -6557,13 +6559,13 @@
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/hallway/primary/upper/south)
 "nv" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
+/obj/machinery/space_heater,
+/obj/machinery/firealarm{
 	dir = 1;
-	icon_state = "grey_railing0"
+	pixel_x = 6;
+	pixel_y = -24
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/snow/plating/cryogaia,
+/turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "nw" = (
 /obj/effect/floor_decal/corner/brown{
@@ -7787,10 +7789,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/miningdock)
 "sX" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Northwest Tower - Upper"
+/obj/structure/catwalk,
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "sY" = (
 /obj/machinery/light/small{
@@ -8525,16 +8530,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "wH" = (
-/obj/machinery/light,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Common Channel";
-	pixel_y = -21
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northwest)
@@ -8751,10 +8749,9 @@
 /turf/simulated/floor/plating/snow/plating,
 /area/maintenance/auxsolarport)
 "xH" = (
-/obj/machinery/door/airlock/glass_external/freezable{
-	req_one_access = list()
-	},
-/turf/simulated/floor/plating/snow/plating,
+/obj/structure/catwalk,
+/obj/structure/railing/grey,
+/turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "xN" = (
 /obj/structure/cable/heavyduty{
@@ -8767,6 +8764,7 @@
 	dir = 8;
 	icon_state = "grey_railing0"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "xP" = (
@@ -8848,8 +8846,10 @@
 /turf/simulated/floor/tiled/white,
 /area/cryogaia/station/medical/upper)
 "yo" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/snow/plating/cryogaia,
+/obj/machinery/door/airlock/glass_external/freezable{
+	req_one_access = list()
+	},
+/turf/simulated/floor/plating/snow/plating,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "ys" = (
 /obj/machinery/door/airlock/glass_security{
@@ -8864,9 +8864,10 @@
 "yv" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
-	dir = 1;
+	dir = 4;
 	icon_state = "grey_railing0"
 	},
+/obj/structure/railing/grey,
 /turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "yw" = (
@@ -9394,9 +9395,16 @@
 /area/chapel/monastery/upper)
 "Bf" = (
 /obj/structure/catwalk,
-/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
 /turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/northwest)
+/area/borealis2/outdoors/grounds/tower/southwest)
 "Bg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9818,17 +9826,18 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
 "Di" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
 	dir = 1;
-	icon_state = "grey_railing0"
+	listening = 1;
+	name = "Common Channel";
+	pixel_y = 21
 	},
-/turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/northwest)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/borealis2/outdoors/grounds/tower/southwest)
 "Dl" = (
 /obj/effect/overmap/visitable/sector/cryogaia,
 /turf/simulated/open/cryogaia,
@@ -9842,14 +9851,11 @@
 /area/crew_quarters/medbreak)
 "Do" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 1;
-	listening = 1;
-	name = "Common Channel";
-	pixel_y = 21
+/obj/item/device/geiger/wall{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
@@ -10318,14 +10324,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/chapel/monastery/upper)
-"FK" = (
-/obj/structure/table/steel,
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/northwest)
 "FL" = (
 /obj/machinery/computer/station_alert/security{
 	dir = 8;
@@ -10623,10 +10621,6 @@
 /area/borealis2/outdoors/grounds/tower/west)
 "HH" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
 	dir = 1;
 	icon_state = "grey_railing0"
 	},
@@ -10676,18 +10670,6 @@
 "HS" = (
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/excursion_dock)
-"HT" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/machinery/light/spot/no_nightshift{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/northwest)
 "HV" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -11065,10 +11047,13 @@
 /area/security/watchtower)
 "JN" = (
 /obj/structure/catwalk,
-/obj/structure/railing/grey,
 /obj/structure/railing/grey{
 	dir = 8;
 	icon_state = "grey_railing0"
+	},
+/obj/machinery/light/spot/no_nightshift{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/open/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northwest)
@@ -11761,14 +11746,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
-"NQ" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/catwalk,
-/turf/simulated/open/cryogaia,
-/area/borealis2/outdoors/grounds/tower/southwest)
 "NR" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
@@ -12897,16 +12874,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel/monastery/upper)
-"TC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/device/geiger/wall{
-	dir = 8;
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/borealis2/outdoors/grounds/tower/northwest)
 "TH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
@@ -13514,9 +13481,6 @@
 	dir = 8;
 	icon_state = "grey_railing0"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "WV" = (
@@ -13837,11 +13801,9 @@
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds/tower/northeast)
 "Yu" = (
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+/obj/machinery/camera/network/security{
+	c_tag = "Northwest Tower - Upper"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "Yx" = (
@@ -15266,14 +15228,14 @@ FC
 om
 WS
 bf
-HT
 iS
-iS
-iS
-iS
-HT
 JN
-gv
+iS
+iS
+iS
+iS
+JN
+sX
 gv
 gv
 gv
@@ -15427,15 +15389,15 @@ ro
 FC
 om
 WS
-lm
+WS
+as
 cH
 Yi
 Yi
 Yi
 Yi
 cH
-Bf
-gv
+xH
 gv
 gv
 gv
@@ -15589,15 +15551,15 @@ ro
 om
 om
 om
-yv
+li
+fZ
 Yi
 Lv
 gD
 gD
-FK
+mb
 Yi
-Bf
-gv
+xH
 gv
 gv
 gv
@@ -15751,15 +15713,15 @@ ro
 om
 om
 om
-nv
+li
+bv
 Yi
-sX
 Yu
 xO
 wH
+mv
 cH
-yo
-Op
+fZ
 Op
 Op
 Op
@@ -15866,7 +15828,7 @@ Op
 Op
 pn
 XP
-mb
+mm
 WT
 XV
 ws
@@ -15913,13 +15875,13 @@ ro
 om
 om
 om
-nv
+om
+bv
 Yi
 Lv
 Lv
 Lv
 Lv
-xH
 yo
 fZ
 Rs
@@ -16028,9 +15990,9 @@ Rs
 Rs
 pn
 js
-js
-js
-Do
+Di
+mm
+mm
 wG
 Mj
 xl
@@ -16075,15 +16037,15 @@ FC
 om
 om
 om
-yv
+om
+fZ
 Yi
 Lv
-TC
+lm
 Lv
-jw
+nv
 cH
-Bf
-nQ
+xH
 nQ
 nQ
 nQ
@@ -16189,9 +16151,9 @@ nQ
 nQ
 nQ
 HH
-NQ
-as
-js
+Mj
+mm
+Do
 mm
 UY
 Mj
@@ -16237,15 +16199,15 @@ om
 om
 om
 nQ
-lm
+nQ
+jw
 cH
 Yi
 cH
 cH
 cH
 cH
-Bf
-nQ
+xH
 nQ
 nQ
 nQ
@@ -16350,9 +16312,9 @@ nQ
 nQ
 nQ
 nQ
-nQ
-nQ
-jW
+xm
+js
+Mj
 js
 XP
 Mj
@@ -16399,15 +16361,15 @@ om
 om
 om
 nQ
-Di
-uS
-uS
-uS
-uS
-uS
-uS
-bv
 nQ
+jW
+uS
+uS
+uS
+uS
+uS
+uS
+yv
 nQ
 nQ
 nQ
@@ -16512,8 +16474,8 @@ nQ
 nQ
 nQ
 nQ
-nQ
-nQ
+Bf
+Rt
 dr
 pn
 pn
@@ -38058,7 +38020,7 @@ Op
 Op
 Op
 Op
-mv
+kI
 lV
 SZ
 MB
@@ -38220,7 +38182,7 @@ Rs
 Rs
 Rs
 Rs
-mv
+kI
 no
 bk
 nh


### PR DESCRIPTION
Does exactly what it says on the tin: fixes #991 by correcting all the issues. Also sticks a radiation-proof notice on the front of the security outpost so folks know it's safe to shelter there if they need to.

Mostly just an excuse to test StrongDMM.