### PR TITLE
Fix X01 stun projectile

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear_yw.dm
+++ b/code/modules/projectiles/guns/energy/nuclear_yw.dm
@@ -59,7 +59,7 @@
 	modifystate = "x01stun"
 
 	firemodes = list(
-		list(mode_name="stun", fire_delay = 8, projectile_type= /obj/item/projectile/energy/electrode/x01stunshot, modifystate="x01stun", fire_sound='sound/weapons/Taser.ogg', charge_cost = 240),
+		list(mode_name="stun", fire_delay = 8, projectile_type= /obj/item/projectile/beam/stun, modifystate="x01stun", fire_sound='sound/weapons/Taser.ogg', charge_cost = 240),
 		list(mode_name="laser", fire_delay = 8, projectile_type=/obj/item/projectile/beam, modifystate="x01laser", fire_sound='sound/weapons/Laser.ogg', charge_cost = 480),
 		list(mode_name="gauss", fire_delay=15, projectile_type=/obj/item/projectile/energy/gauss, modifystate="x01gauss", fire_sound='sound/weapons/gauss_shoot.ogg', charge_cost = 360)
 		)


### PR DESCRIPTION
It starts out as a taser beam. When you cycle through the modes and come back to the stun setting, it starts shooting an electrode instead. This fixes that and sets it back to the taser beam.