### PR TITLE
Bunch of atmospherics and disposals fixes.

### DIFF
--- a/maps/yw/cryogaia-02-mining.dmm
+++ b/maps/yw/cryogaia-02-mining.dmm
@@ -180,7 +180,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/outpost/research/atmosia)
 "au" = (
 /mob/living/simple_mob/animal/space/carp/large,
@@ -213,18 +213,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "az" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "aA" = (
@@ -295,6 +290,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/blue,
 /obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "aH" = (
@@ -1029,6 +1034,16 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "cw" = (
@@ -1459,6 +1474,9 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 6
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
 "dF" = (
@@ -1552,6 +1570,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
+"dQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/hallway)
 "dR" = (
 /obj/structure/cable/blue{
 	d2 = 8;
@@ -1603,9 +1636,7 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
 /obj/item/device/taperecorder,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood,
 /area/outpost/research/hallway/mid)
 "dZ" = (
@@ -1864,11 +1895,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
@@ -2195,7 +2226,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/rnd/outpost/mixing)
 "fy" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/west_hall)
 "fz" = (
@@ -2261,7 +2292,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "fG" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -2426,7 +2456,7 @@
 /area/outpost/mining_main/refinery)
 "fY" = (
 /obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -2656,6 +2686,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/xenobiology/xenoflora)
+"gz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/hallway)
 "gA" = (
 /turf/simulated/wall,
 /area/outpost/mining_main/dorms2)
@@ -2707,6 +2751,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/hallway)
+"gH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/research/eva)
 "gI" = (
 /turf/simulated/wall,
 /area/rnd/xenobiology/xenoflora_storage)
@@ -2842,13 +2895,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -2856,25 +2902,34 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
 /obj/structure/cable/blue{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
 "gW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
@@ -2929,14 +2984,9 @@
 /turf/simulated/floor/tiled,
 /area/gateway)
 "hd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/secure)
 "hg" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
 /turf/simulated/floor/tiled/old_tile/gray,
@@ -3637,9 +3687,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/surgery)
 "iR" = (
@@ -3733,8 +3780,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4017,12 +4062,6 @@
 	req_access = list(47)
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -4075,6 +4114,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/power)
+"jX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/research/anomaly)
 "jZ" = (
 /obj/item/weapon/material/shard,
 /obj/item/device/electronic_assembly/clothing/large,
@@ -4277,8 +4330,6 @@
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "kE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -4288,6 +4339,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
@@ -4339,7 +4396,6 @@
 /area/rnd/test_area)
 "kO" = (
 /obj/machinery/portable_atmospherics/powered/pump,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
 	},
@@ -4347,6 +4403,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/rnd/workshop)
 "kQ" = (
@@ -4412,6 +4469,16 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/blast/regular{
 	id = "xbio2"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
@@ -4608,10 +4675,6 @@
 /area/rnd/outpost/launch)
 "lw" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
 	},
@@ -4856,6 +4919,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/mixing)
 "lY" = (
@@ -5012,22 +5081,29 @@
 /area/rnd/xenobiology/xenoflora_storage)
 "mt" = (
 /obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular{
+	id = "xbio4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/outpost/mining_main/break_room)
+/area/rnd/xenobiology/secure)
 "mu" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -5052,7 +5128,8 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/secure)
 "mw" = (
 /obj/machinery/light{
@@ -5211,11 +5288,11 @@
 /turf/simulated/wall/r_wall,
 /area/vacant/vacant_site/east)
 "mP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
@@ -5278,9 +5355,7 @@
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/tape_roll,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "mY" = (
@@ -5356,7 +5431,7 @@
 	name = "Science Maintenance"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/outpost/research/atmosia)
 "nj" = (
 /obj/machinery/firealarm{
@@ -5885,10 +5960,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
 "oB" = (
-/obj/machinery/alarm{
-	frequency = 1441;
-	pixel_y = 22
-	},
 /obj/machinery/recharger,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
@@ -5987,19 +6058,7 @@
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/research/anomaly)
-"oM" = (
-/obj/structure/anomaly_container,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
@@ -6071,6 +6130,10 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/minihoe,
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
 "oT" = (
@@ -6286,12 +6349,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/xenobiology/failsafe)
 "pz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "pA" = (
@@ -6324,9 +6385,6 @@
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
 	},
 /obj/item/weapon/storage/box/solution_trays,
 /obj/machinery/alarm{
@@ -6953,13 +7011,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -6967,13 +7018,20 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/structure/cable/blue{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/structure/cable/blue{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -7115,6 +7173,9 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/secure)
 "rm" = (
@@ -7129,6 +7190,16 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/blast/regular{
 	id = "xbio1"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
@@ -7237,6 +7308,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/airlock)
+"rB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/rnd/xenobiology)
 "rC" = (
 /obj/structure/cable/blue{
 	d1 = 1;
@@ -7287,6 +7367,9 @@
 /area/outpost/research/eva)
 "rN" = (
 /obj/machinery/photocopier,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/secure)
 "rO" = (
@@ -7530,6 +7613,9 @@
 	layer = 4;
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/hallway/mid)
 "sv" = (
@@ -7586,12 +7672,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/hallway)
 "sF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/south_hall)
@@ -7799,9 +7885,6 @@
 /area/mine/explored)
 "tr" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/weapon/tool/wirecutters,
@@ -7811,6 +7894,10 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/recharger,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/secure)
 "tu" = (
@@ -7872,9 +7959,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -7889,6 +7973,9 @@
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
@@ -8034,18 +8121,9 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway/mid)
 "tZ" = (
-/obj/machinery/atmospherics/valve/digital/open,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/research/anomaly)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology)
 "ua" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8255,9 +8333,6 @@
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "uw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -8355,9 +8430,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
@@ -8482,8 +8554,6 @@
 	req_access = list(65)
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -8670,9 +8740,6 @@
 /area/rnd/xenobiology/xenoflora_storage)
 "vt" = (
 /obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -8980,6 +9047,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/south_hall)
+"wm" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/hallway)
 "wn" = (
 /obj/effect/landmark{
 	name = "bluespacerift"
@@ -9005,6 +9081,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "wr" = (
@@ -9148,9 +9225,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9223,14 +9297,16 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway/mid)
 "wN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/south_hall)
@@ -9248,7 +9324,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
 "wP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -9394,6 +9470,21 @@
 "xp" = (
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/north_hall)
+"xq" = (
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/west_hall)
 "xr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
@@ -9431,17 +9522,17 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/airlock)
 "xw" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway/mid)
@@ -9512,6 +9603,16 @@
 	icon_state = "0-8"
 	},
 /obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "xG" = (
@@ -9683,7 +9784,6 @@
 /obj/item/weapon/folder,
 /obj/item/device/camera,
 /obj/item/weapon/pen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -9739,8 +9839,10 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/mining_main/medbay)
 "yi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/heating)
 "yj" = (
@@ -9823,7 +9925,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -32
@@ -9860,12 +9961,20 @@
 /turf/simulated/floor/plating,
 /area/outpost/research/atmosia)
 "yx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/hallway)
 "yy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -10072,17 +10181,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_north)
 "yS" = (
-/obj/structure/cable/blue{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/hallway)
 "yU" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/purple{
@@ -10252,15 +10358,15 @@
 /obj/structure/closet/hydrant{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "zt" = (
@@ -10295,9 +10401,6 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/secure)
 "zw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 2;
 	d2 = 4;
@@ -10422,7 +10525,7 @@
 	pixel_y = -21
 	},
 /obj/item/device/suit_cooling_unit,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -10503,9 +10606,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
@@ -10565,10 +10665,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/workshop)
@@ -10708,6 +10808,16 @@
 	},
 /obj/structure/cable/blue,
 /obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "Ay" = (
@@ -11062,9 +11172,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11232,6 +11339,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway/mid)
+"BD" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/hallway)
 "BE" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable/blue{
@@ -11370,6 +11484,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
@@ -11615,9 +11732,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
@@ -11678,11 +11792,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/hallway)
@@ -11914,14 +12028,15 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/blue,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
 "Dk" = (
@@ -11958,9 +12073,6 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/mining_main/medbay)
 "Dm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -12029,6 +12141,12 @@
 "Dr" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
@@ -12219,7 +12337,6 @@
 /area/rnd/outpost/mixing)
 "DX" = (
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
-/obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -12437,13 +12554,13 @@
 /turf/simulated/floor/wood,
 /area/outpost/research/hallway/mid)
 "Ew" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
@@ -12537,11 +12654,6 @@
 "EF" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -12549,15 +12661,20 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/cable/blue{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -12577,13 +12694,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -12591,13 +12701,20 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
+/obj/structure/cable/blue{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/structure/cable/blue{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -12782,7 +12899,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/secure)
 "Fe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/airlock)
 "Ff" = (
@@ -12895,6 +13012,9 @@
 /area/outpost/mining_north)
 "Fs" = (
 /obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -13186,11 +13306,6 @@
 "Gi" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -13198,15 +13313,20 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/cable/blue{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -13252,11 +13372,6 @@
 "Gr" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -13264,18 +13379,23 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/blue{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -13680,9 +13800,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
@@ -13714,11 +13831,6 @@
 "Hs" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -13726,15 +13838,20 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/cable/blue{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -13765,6 +13882,9 @@
 /obj/structure/table/standard,
 /obj/item/weapon/weldingtool,
 /obj/item/clothing/glasses/welding,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/workshop)
 "Hz" = (
@@ -13870,6 +13990,7 @@
 "HJ" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/west_hall)
 "HK" = (
@@ -13890,9 +14011,6 @@
 	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
 	},
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -13948,9 +14066,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/north_hall)
 "HZ" = (
@@ -14000,6 +14116,16 @@
 	},
 /obj/structure/cable/blue,
 /obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "Ie" = (
@@ -14166,10 +14292,6 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/xenobiology/xenoflora_storage)
 "IA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -14177,6 +14299,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/west_hall)
@@ -14393,6 +14519,9 @@
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/south_hall)
 "IV" = (
@@ -14426,14 +14555,14 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/outpost/research/eva)
@@ -14810,13 +14939,6 @@
 "JV" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14824,16 +14946,31 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
 /obj/structure/cable/blue{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
+"JW" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(65)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/outpost/research/eva)
 "JX" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/steel_dirty,
@@ -14921,6 +15058,9 @@
 /area/rnd/test_area)
 "Kk" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/outpost/research/hallway/mid)
 "Kl" = (
@@ -14982,9 +15122,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "Ku" = (
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -15258,9 +15395,6 @@
 "Lb" = (
 /obj/structure/table/standard,
 /obj/item/weapon/hand_labeler,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -15279,6 +15413,16 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/blast/regular{
 	id = "xbio2"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
@@ -15439,7 +15583,7 @@
 	dir = 9
 	},
 /obj/machinery/computer/area_atmos,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -15474,6 +15618,16 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/blast/regular{
 	id = "xbio3"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
@@ -15545,6 +15699,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/blue,
 /obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "LK" = (
@@ -15742,10 +15906,13 @@
 /turf/simulated/shuttle/wall/voidcraft/red,
 /area/borealis2/elevator/scimining)
 "Mh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "Mk" = (
@@ -15910,8 +16077,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/workshop)
@@ -16154,12 +16321,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/maintenance)
@@ -16466,15 +16627,15 @@
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "NW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/camera/network/mining{
 	c_tag = "OPM - Mining Dorms";
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/west_hall)
@@ -16599,8 +16760,6 @@
 	req_access = list(48)
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/north_hall)
@@ -16859,7 +17018,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/test_area)
 "OP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/west_hall)
 "OQ" = (
@@ -16920,9 +17079,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -16971,6 +17127,10 @@
 	pixel_x = 5
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/secure)
 "Pd" = (
@@ -17452,13 +17612,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "Qp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/airlock)
@@ -17891,10 +18051,6 @@
 	pixel_x = 5
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25
-	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/break_room)
 "Rw" = (
@@ -17945,6 +18101,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/longtermstorage)
+"RE" = (
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp,
+/obj/machinery/recharger,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/xenobiology/secure)
 "RF" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -18026,9 +18191,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -18038,6 +18200,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/hallway/mid)
 "RR" = (
@@ -18170,6 +18335,7 @@
 /obj/structure/table/glass,
 /obj/item/weapon/tape_roll,
 /obj/item/device/analyzer/plant_analyzer,
+/obj/item/weapon/material/minihoe,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "Sm" = (
@@ -18273,6 +18439,16 @@
 /obj/machinery/door/blast/regular{
 	id = "xbio3"
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "Su" = (
@@ -18356,6 +18532,9 @@
 /obj/item/clothing/under/rank/miner,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/west_hall)
@@ -18792,6 +18971,16 @@
 /obj/machinery/door/blast/regular{
 	id = "xbio1"
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
 "TB" = (
@@ -18872,6 +19061,16 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/blast/regular{
 	id = "xbio4"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/secure)
@@ -19027,11 +19226,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/rnd/xenobiology/failsafe)
 "Uj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/requests_console/preset/research{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/outpost/research/hallway/mid)
@@ -19650,12 +19849,10 @@
 /obj/item/weapon/pen,
 /obj/item/weapon/melee/baton/slime/loaded,
 /obj/item/weapon/gun/energy/taser/xeno,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/secure)
 "VQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
@@ -19808,10 +20005,10 @@
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "Wh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -19850,9 +20047,6 @@
 /turf/simulated/wall,
 /area/rnd/outpost/mixing)
 "Wm" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/camera/network/mining{
 	c_tag = "OPM - Mining Hallway Aft";
 	dir = 4
@@ -19975,6 +20169,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "High Security Xenobiology"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/secure)
@@ -20402,16 +20599,16 @@
 /turf/simulated/wall,
 /area/outpost/research/disposal)
 "Xy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/outpost/research/disposal)
@@ -20643,7 +20840,6 @@
 /area/rnd/outpost/launch)
 "Ye" = (
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
-/obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -20812,7 +21008,6 @@
 /area/rnd/hallway)
 "Yw" = (
 /obj/machinery/portable_atmospherics/canister/empty/nitrous_oxide,
-/obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -20893,14 +21088,12 @@
 /area/rnd/xenobiology/secure)
 "YH" = (
 /obj/structure/anomaly_container,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/research/anomaly)
 "YI" = (
@@ -20918,7 +21111,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 2;
@@ -20978,6 +21170,7 @@
 "YR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/tape_roll,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/outpost/research/hallway/mid)
 "YT" = (
@@ -21120,6 +21313,12 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
 "Zl" = (
@@ -21147,8 +21346,8 @@
 /area/outpost/mining_main/break_room)
 "Zo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/workshop)
@@ -21255,9 +21454,6 @@
 	dir = 1;
 	pixel_x = 4;
 	pixel_y = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/workshop)
@@ -34846,12 +35042,12 @@ kE
 nJ
 wO
 wO
+yx
+dQ
 wO
 wO
 wO
-wO
-wO
-wO
+gz
 wg
 PP
 cB
@@ -35008,12 +35204,12 @@ qh
 qh
 qh
 xi
+yS
+wm
 qh
 qh
 qh
-qh
-qh
-qh
+BD
 vD
 Ft
 bF
@@ -36021,7 +36217,7 @@ fy
 OP
 IA
 wP
-mt
+Na
 WR
 fV
 ib
@@ -36180,8 +36376,8 @@ cS
 zE
 iK
 HJ
-Ge
-AN
+OP
+xq
 SC
 jJ
 PD
@@ -36940,16 +37136,16 @@ am
 Og
 uZ
 PZ
-ta
+tZ
 ta
 ta
 LK
 MT
-Ms
+rB
 MT
 fF
 Qc
-hd
+rB
 MT
 MT
 MT
@@ -37099,7 +37295,7 @@ pv
 ta
 ta
 co
-hd
+Ms
 KG
 wc
 OU
@@ -37597,7 +37793,7 @@ Ms
 MT
 fF
 MT
-hd
+Ms
 MT
 MT
 Pz
@@ -38447,8 +38643,8 @@ If
 TW
 TW
 Xu
-yx
-yS
+MZ
+yN
 wG
 ry
 fX
@@ -39034,7 +39230,7 @@ tV
 sV
 sV
 sV
-sV
+hd
 RL
 yn
 GL
@@ -39358,7 +39554,7 @@ Nb
 sV
 pI
 Nb
-tt
+RE
 rl
 Nb
 fH
@@ -40006,7 +40202,7 @@ Nb
 Nb
 TP
 sS
-TP
+mt
 Nb
 xF
 yo
@@ -42007,8 +42203,8 @@ Ls
 YE
 nU
 Zj
-OS
-CM
+JW
+gH
 CM
 OS
 Zl
@@ -43606,7 +43802,7 @@ Ew
 wp
 mX
 Mh
-oM
+YH
 OC
 OC
 OC
@@ -43764,7 +43960,7 @@ cp
 iv
 fP
 Pq
-tZ
+hh
 sL
 UF
 KC
@@ -44254,7 +44450,7 @@ cy
 sa
 xP
 eJ
-ya
+jX
 Yi
 Qf
 SW

--- a/maps/yw/cryogaia-04-maintenance.dmm
+++ b/maps/yw/cryogaia-04-maintenance.dmm
@@ -228,21 +228,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aiR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbaylower)
 "ajv" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = -32
@@ -255,15 +240,15 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/mirror{
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_4)
@@ -276,10 +261,10 @@
 /area/security/sorting)
 "ajL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/sleep/cryo)
@@ -469,7 +454,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -808,6 +792,7 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
 "aEG" = (
@@ -824,9 +809,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/south)
 "aFa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
 "aFj" = (
@@ -1412,7 +1401,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -1616,9 +1605,6 @@
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Atmospherics";
 	req_access = list(24)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1894,11 +1880,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "bnK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
+/turf/simulated/floor/tiled,
+/area/hallway/lower/fore)
 "bnV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1924,11 +1911,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Hydroponics";
 	sortType = "Hydroponics"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/central)
@@ -2015,7 +2004,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
@@ -2212,7 +2201,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/sleep/cryo)
 "bDH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/maintenance/dormitory)
 "bDK" = (
@@ -2258,8 +2246,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2272,10 +2262,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "bGj" = (
@@ -2997,11 +2983,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ccp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/bluegrid,
-/area/ai)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/fore)
 "ccr" = (
 /obj/item/device/geiger/wall{
 	dir = 8;
@@ -3069,14 +3063,14 @@
 /turf/simulated/floor,
 /area/maintenance/starboard)
 "cet" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "frame";
 	pixel_y = -32
 	},
 /obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "ceH" = (
@@ -3405,10 +3399,10 @@
 /turf/simulated/floor/water/hotspring,
 /area/chapel/chapel_morgue)
 "cqt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -3827,7 +3821,7 @@
 /turf/simulated/floor/wood/sif/broken,
 /area/maintenance/blueserg/misc)
 "cDb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3867,7 +3861,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -3880,10 +3874,10 @@
 	pixel_x = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -4120,7 +4114,6 @@
 /area/crew_quarters/sleep/cryo)
 "cNc" = (
 /obj/machinery/door/firedoor/glass/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
@@ -4219,12 +4212,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "cPU" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/dormitory)
+/turf/simulated/floor/tiled/white,
+/area/medical/pyschwarde)
 "cQf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4346,12 +4338,12 @@
 /area/crew_quarters/coffee_shop)
 "cSg" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "frame";
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
@@ -4476,22 +4468,21 @@
 /area/holodeck_control)
 "cWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "cXp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/dorm)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbaylower)
 "cXQ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -4550,11 +4541,19 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
 "dbr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/dormitory)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbaylower)
 "dbT" = (
 /obj/structure/safe/floor{
 	name = "Vault of Memories"
@@ -4736,13 +4735,13 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "dfq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics)
@@ -4768,15 +4767,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "dga" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/emergency/eva)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbaylower)
 "dgF" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 8
@@ -4845,11 +4847,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "dlM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/computer/cryopod{
 	layer = 3.3;
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "dma" = (
@@ -4938,8 +4940,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "dnF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/emergency/eva)
@@ -5042,6 +5047,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
 "dqB" = (
@@ -5308,6 +5314,7 @@
 	name = "Restroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_4)
 "dyu" = (
@@ -5429,9 +5436,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/fore)
 "dDi" = (
@@ -5566,8 +5571,6 @@
 	layer = 3.1;
 	name = "Cafe Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "dJR" = (
@@ -5861,11 +5864,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "dSV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/item/weapon/bedsheet/orange,
 /obj/structure/bed/padded,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "dSW" = (
@@ -6401,7 +6404,7 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "ejr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -6480,10 +6483,10 @@
 /area/library)
 "elo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
@@ -6552,7 +6555,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "enk" = (
@@ -6664,15 +6667,15 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "epP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_4)
@@ -7103,7 +7106,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
 "eDD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7175,19 +7178,16 @@
 /turf/simulated/wall,
 /area/hallway/lower/aft)
 "eHi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbaylower)
 "eHC" = (
 /obj/structure/cryofeed{
 	dir = 4
@@ -7395,7 +7395,7 @@
 /turf/simulated/floor,
 /area/engineering/atmos)
 "ePf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -7413,7 +7413,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge{
 	starts_with = list(/obj/item/weapon/reagent_containers/food/drinks/milk = 6, /obj/item/weapon/storage/fancy/egg_box = 4, /obj/item/weapon/reagent_containers/food/condiment/flour = 7, /obj/item/weapon/reagent_containers/food/condiment/sugar = 2)
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "eQh" = (
@@ -7508,10 +7507,10 @@
 /area/vacant/vacant_site/locker)
 "eTq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/security/perma)
@@ -7532,10 +7531,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/starboard)
 "eUN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/wood,
@@ -7747,11 +7746,11 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/starboard)
 "feh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/fore)
+/turf/simulated/floor/tiled/dark,
+/area/medical/biostorage2)
 "fex" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -7838,7 +7837,7 @@
 "fiG" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/brown,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "fiX" = (
@@ -7867,7 +7866,6 @@
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	name = "Construction Site"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/dormitory)
 "fjV" = (
@@ -7942,14 +7940,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/west)
 "flQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbaylower)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/sleep/cryo)
 "flV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/wood,
@@ -8483,6 +8486,9 @@
 "fCw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
+/obj/machinery/atmospherics/pipe/cap/visible/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
 "fCK" = (
@@ -8715,13 +8721,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "fNs" = (
@@ -8777,12 +8779,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
@@ -9414,7 +9416,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fish)
 "gii" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "gjv" = (
@@ -9507,16 +9509,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
 "gmI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics)
@@ -9620,7 +9622,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "grw" = (
@@ -9805,7 +9807,7 @@
 /area/security/perma)
 "gvi" = (
 /obj/structure/table/gamblingtable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -10097,9 +10099,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/prison)
 "gEv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -32
 	},
@@ -10229,9 +10228,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -10512,9 +10508,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "gTI" = (
@@ -10800,7 +10793,6 @@
 /obj/item/weapon/autopsy_scanner,
 /obj/item/weapon/surgical/scalpel,
 /obj/item/weapon/surgical/cautery,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "haS" = (
@@ -11260,10 +11252,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "hnP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -11429,7 +11421,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/storage)
 "huA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -11535,10 +11527,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "hxT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "hxY" = (
@@ -11594,9 +11586,6 @@
 /area/hallway/primary/starboard)
 "hyX" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11611,15 +11600,12 @@
 /area/civilian/atrium/lower)
 "hzd" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "frame";
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
@@ -11744,12 +11730,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "hDZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
 	dir = 1
@@ -11805,13 +11785,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/emergency/eva)
 "hFn" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
 "hFD" = (
@@ -12081,8 +12062,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tcomfoyer)
@@ -12231,8 +12212,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/fish_farm)
 "hTA" = (
@@ -12542,7 +12521,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/lino,
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ibz" = (
 /obj/structure/closet/crate/mimic/cointoss,
@@ -12920,9 +12899,6 @@
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/weapon/storage/belt/utility,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
 /obj/random/maintenance/security,
@@ -13002,10 +12978,10 @@
 /area/library)
 "iot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
@@ -13114,12 +13090,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/fish_farm)
@@ -13289,6 +13259,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "iuZ" = (
@@ -13330,9 +13303,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -13690,9 +13660,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/machinery/button/remote/airlock{
 	id = "dorm2";
 	name = "Room 2 Lock";
@@ -13700,6 +13667,7 @@
 	pixel_y = -26;
 	specialfunctions = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "iGJ" = (
@@ -13835,12 +13803,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
 "iKG" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/cap/visible/supply{
+	dir = 8
 	},
 /turf/simulated/floor,
-/area/maintenance/dormitory)
+/area/vacant/vacant_site)
 "iKT" = (
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
@@ -13907,11 +13877,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
-"iMQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/lower/central)
 "iMR" = (
 /obj/structure/sign/poster,
 /turf/simulated/wall/titanium,
@@ -14461,8 +14426,6 @@
 	req_access = list(28)
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14833,12 +14796,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "jpM" = (
@@ -14851,8 +14808,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
-/obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /obj/structure/cable{
 	icon_state = "16-0"
 	},
@@ -15011,21 +14966,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/fore)
 "jwb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/medical/virology)
+/area/vacant/vacant_shop)
 "jxh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15296,9 +15241,6 @@
 /area/engineering/hallway_lower)
 "jCg" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance/medical,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15418,9 +15360,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medical_lower)
 "jGa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -15898,10 +15837,6 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light_switch{
 	pixel_x = -12;
 	pixel_y = -24
@@ -15995,18 +15930,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "jVi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/door/airlock{
 	id_tag = "visitdoor";
 	name = "Visitation Area";
 	req_access = list(63)
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/medical/pyschwarde)
 "jVu" = (
@@ -16205,9 +16136,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -16582,11 +16510,11 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
@@ -16964,7 +16892,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -17103,9 +17031,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay_emt_storage)
 "kvz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -17116,6 +17041,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/computer)
@@ -17506,9 +17434,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -17718,9 +17643,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lowfloor1)
 "kMD" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -18270,6 +18192,12 @@
 /obj/effect/landmark{
 	name = "vinestart"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
 "lem" = (
@@ -18443,7 +18371,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/space_heater,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -18646,6 +18574,9 @@
 /area/crew_quarters/sleep/Dorm_3)
 "lpw" = (
 /obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/starboard)
 "lpD" = (
@@ -18746,7 +18677,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/emergency/eva)
 "luw" = (
@@ -18795,9 +18726,6 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "lvv" = (
@@ -18833,7 +18761,6 @@
 	dir = 1
 	},
 /obj/item/weapon/gun/energy/laser/practice,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "lwk" = (
@@ -18902,11 +18829,11 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/mirror{
 	pixel_x = -28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_6)
@@ -18919,7 +18846,6 @@
 /area/medical/virology)
 "lyQ" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 4
 	},
@@ -19022,6 +18948,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "lDh" = (
@@ -19049,10 +18978,10 @@
 /area/security/perma/control)
 "lDR" = (
 /obj/structure/table/gamblingtable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/random/toy,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/random/toy,
 /turf/simulated/floor/wood,
 /area/maintenance/dorm)
 "lDX" = (
@@ -19885,9 +19814,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 1
-	},
 /obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/medical_lower)
@@ -19895,15 +19821,13 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
 "mct" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "mcW" = (
@@ -20410,7 +20334,6 @@
 /turf/simulated/wall,
 /area/engineering/hallway_lower)
 "mxW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
@@ -20438,17 +20361,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/kitchen/fish_farm)
 "myv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
@@ -20549,9 +20466,6 @@
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = -32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/emergency/eva)
@@ -20804,6 +20718,9 @@
 	dir = 8
 	},
 /obj/structure/cable/green,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/emergency/eva)
 "mHo" = (
@@ -21527,6 +21444,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
 "nev" = (
@@ -22096,7 +22014,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "nxP" = (
@@ -22125,7 +22042,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/aft)
 "nzh" = (
@@ -22133,7 +22049,7 @@
 /turf/simulated/floor,
 /area/maintenance/aft)
 "nzu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -22158,12 +22074,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/fish_farm)
@@ -22306,12 +22216,12 @@
 /area/chapel/main)
 "nGd" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "frame";
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
@@ -22460,13 +22370,13 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/mirror{
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_2)
 "nOd" = (
@@ -22645,7 +22555,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/starboard)
 "nUE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -22654,6 +22563,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/emergency/eva)
 "nUX" = (
@@ -23022,7 +22932,6 @@
 /area/maintenance/lowfloor2)
 "ody" = (
 /obj/structure/table/rack,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -23037,6 +22946,7 @@
 	pixel_y = 24;
 	req_access = list()
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/emergency/eva)
 "odz" = (
@@ -23134,12 +23044,12 @@
 /area/security/brig/visitation)
 "ohC" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "frame";
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
@@ -23194,9 +23104,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/dormitory)
 "oju" = (
@@ -23211,11 +23118,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/lower)
@@ -23453,9 +23360,7 @@
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
 "osK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -23532,10 +23437,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/fore)
@@ -24017,7 +23924,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_lower)
 "oLS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -24852,10 +24759,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -24930,9 +24835,9 @@
 /area/maintenance/atmos_control)
 "pkm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "pko" = (
@@ -25013,10 +24918,10 @@
 	},
 /area/tcommsat/chamber)
 "plZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/emergency/eva)
 "pmi" = (
@@ -25031,15 +24936,15 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
@@ -25296,7 +25201,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/emergency/eva)
@@ -25574,11 +25479,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
 "pDR" = (
@@ -25606,12 +25511,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
@@ -25753,7 +25652,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = -21
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/library)
 "pJx" = (
@@ -26397,10 +26296,10 @@
 /area/engineering/atmos)
 "qca" = (
 /obj/structure/table/bench/padded,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/camera/network/civilian{
 	dir = 8
 	},
-/obj/machinery/camera/network/civilian{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -26529,7 +26428,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "qdX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -26648,12 +26547,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/fish_farm)
 "qhb" = (
@@ -26704,6 +26597,8 @@
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/central)
 "qjD" = (
@@ -27261,15 +27156,15 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/borealis2/elevator/dorms)
@@ -27496,7 +27391,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -28498,8 +28393,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/lower)
@@ -29191,11 +29084,12 @@
 	},
 /area/tcommsat/chamber)
 "rRN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/dormitory)
+/turf/simulated/floor/tiled,
+/area/security/perma)
 "rRX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29468,8 +29362,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
@@ -29568,10 +29460,13 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_shop)
 "sfr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/central)
 "sgn" = (
@@ -29847,13 +29742,14 @@
 /area/maintenance/blueserg)
 "srM" = (
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/pyschwarde)
 "ssd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/wood,
@@ -29882,10 +29778,10 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaylower)
 "stj" = (
@@ -29936,8 +29832,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/dorms)
@@ -30006,9 +29900,6 @@
 "swD" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "swO" = (
@@ -30018,7 +29909,7 @@
 /turf/simulated/floor/water/deep/pool,
 /area/crew_quarters/pool)
 "swP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -30237,9 +30128,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lowfloor1)
 "sDm" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -30388,10 +30276,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
@@ -30685,13 +30573,13 @@
 	req_access = list(39)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "sRs" = (
@@ -30838,12 +30726,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
@@ -31032,6 +30914,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/dorm)
@@ -31405,9 +31293,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
 	dir = 8;
@@ -31566,8 +31451,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/lower)
 "trc" = (
@@ -31792,7 +31675,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "txL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_9)
 "txV" = (
@@ -31806,10 +31689,8 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "tyD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31817,8 +31698,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "tyY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -31956,7 +31837,7 @@
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
 "tEo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -32360,10 +32241,10 @@
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "tNw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/wood,
@@ -32677,10 +32558,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -33144,7 +33025,6 @@
 /turf/simulated/floor,
 /area/maintenance/dormitory)
 "uiw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -33152,6 +33032,7 @@
 	id = "IAflash";
 	pixel_x = 30
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/pyschwarde)
 "uiD" = (
@@ -33193,12 +33074,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/fish_farm)
@@ -34185,7 +34060,7 @@
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
 "uMo" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "uMA" = (
@@ -34572,10 +34447,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -34827,10 +34702,10 @@
 /turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "vhk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -34995,9 +34870,6 @@
 /area/crew_quarters/coffee_shop)
 "vlW" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -35016,6 +34888,9 @@
 	},
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Emergency EVA";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35094,7 +34969,7 @@
 "voU" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/brown,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "vpn" = (
@@ -35113,7 +34988,7 @@
 /turf/simulated/floor,
 /area/maintenance/starboard)
 "vpD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
@@ -35299,9 +35174,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/aft)
 "vxV" = (
@@ -35416,6 +35288,7 @@
 	name = "Restroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_2)
 "vBA" = (
@@ -35680,17 +35553,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "vJB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbaylower)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "vJD" = (
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
@@ -35759,10 +35629,25 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "vLS" = (
+/obj/structure/closet/crate/medical{
+	name = "Empty Medkit Boxes"
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/biostorage3)
 "vLW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_10)
 "vMm" = (
@@ -35790,12 +35675,12 @@
 /area/medical/morgue)
 "vMU" = (
 /obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "frame";
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
@@ -35882,14 +35767,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
 "vPm" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/floor/tiled,
+/area/hallway/lower/dorms)
 "vPS" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -35949,6 +35834,12 @@
 "vQj" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/dorm)
 "vQr" = (
@@ -36259,9 +36150,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/entrance)
 "waQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/lower/aft)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/computer)
 "waX" = (
 /turf/simulated/floor/lino,
 /area/chapel/office)
@@ -36499,15 +36400,15 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/lower)
 "wiL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/central)
@@ -37005,6 +36906,10 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dorm_10)
 "wCK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/pyschwarde)
 "wDf" = (
@@ -37277,9 +37182,9 @@
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos)
 "wNz" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/weapon/bedsheet/orange,
 /obj/structure/bed/padded,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/perma)
 "wOb" = (
@@ -37740,10 +37645,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/cigbutt/cigarbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/maintenance/dorm)
@@ -38158,6 +38060,12 @@
 /area/maintenance/security_lower)
 "xoS" = (
 /obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/hallway/lower/dorms)
 "xpj" = (
@@ -38215,6 +38123,8 @@
 /area/crew_quarters/sleep/engi_wash)
 "xpN" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/central)
 "xpS" = (
@@ -38272,7 +38182,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/aft)
 "xqP" = (
@@ -38618,9 +38530,6 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "xAm" = (
@@ -38801,9 +38710,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medical_lower)
 "xED" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/computer)
 "xEO" = (
@@ -38843,11 +38750,21 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "xFS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/aft)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/engineering/atmos)
 "xGm" = (
 /obj/structure/grille,
 /obj/machinery/meter,
@@ -39222,8 +39139,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/maintroom5)
 "xTV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/maintenance/dorm)
@@ -39415,6 +39335,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -43154,7 +43077,7 @@ lGw
 vpn
 evz
 pzY
-jwb
+kyh
 bQF
 cTf
 ctl
@@ -46428,7 +46351,7 @@ ubF
 uiD
 cdg
 dlM
-hxT
+rRN
 swP
 efh
 ueP
@@ -46556,7 +46479,7 @@ tOY
 hPJ
 dtg
 dtg
-dtg
+feh
 oAI
 hPJ
 rtF
@@ -46868,8 +46791,8 @@ ofm
 jPv
 wXa
 tCH
-oCH
-aUi
+dbr
+eHi
 syq
 qIm
 aGo
@@ -46950,7 +46873,7 @@ wEJ
 dxe
 jrb
 rlD
-mGA
+xFS
 iDT
 vqh
 cZU
@@ -48001,8 +47924,8 @@ bMa
 bek
 aUi
 rXL
-flQ
-vJB
+dQv
+ojJ
 rMV
 vRU
 oUv
@@ -48813,7 +48736,7 @@ aCC
 aCC
 tCH
 uZC
-qwl
+nRN
 vRU
 cMu
 sZN
@@ -48973,8 +48896,8 @@ llz
 srM
 wCK
 jVi
-tCH
-eDC
+cXp
+dga
 tuI
 vRU
 vRU
@@ -49133,11 +49056,11 @@ rCe
 lrK
 veQ
 uiw
-wCK
+cPU
 aCC
 ssL
-aiR
-nRN
+fOX
+uAY
 twQ
 ixT
 ixT
@@ -49173,7 +49096,7 @@ lsp
 lsp
 ibO
 cHk
-mIl
+iKG
 mIl
 luY
 mIl
@@ -49461,7 +49384,7 @@ qbn
 cnD
 hFn
 fOX
-qwl
+uAY
 twQ
 twQ
 ixT
@@ -50452,7 +50375,7 @@ mwd
 cJP
 qaJ
 qaJ
-qYK
+flQ
 dfV
 bjf
 uDm
@@ -50489,7 +50412,7 @@ sHA
 pqI
 pJp
 cFp
-vPm
+knG
 pqI
 stj
 kBc
@@ -51435,7 +51358,7 @@ naU
 eZi
 dRg
 sYR
-eHi
+doI
 nNH
 oen
 hMe
@@ -51561,7 +51484,7 @@ sMf
 pdF
 eHX
 ptH
-dga
+jTg
 mBB
 wpv
 tGi
@@ -51597,7 +51520,7 @@ nFi
 dRg
 dRg
 hhk
-tyD
+doI
 nNH
 lZA
 hMe
@@ -51759,7 +51682,7 @@ mrH
 dBA
 hMe
 sAH
-tyD
+doI
 nNH
 rcX
 hMe
@@ -51921,7 +51844,7 @@ mrH
 ogO
 oCy
 iXp
-tyD
+doI
 jLt
 xyK
 oTx
@@ -52522,9 +52445,9 @@ cgb
 fJz
 ilH
 xot
-lYO
+bnK
 ouo
-feh
+ouo
 ouo
 jMc
 lYO
@@ -52684,7 +52607,7 @@ mfS
 gEQ
 cit
 nXJ
-bUT
+ccp
 bUT
 ouU
 cnp
@@ -52837,7 +52760,7 @@ xMV
 oxt
 oxt
 iSu
-ccp
+tET
 rKA
 wBG
 utq
@@ -52846,7 +52769,7 @@ vgS
 hHK
 dNd
 eXq
-ouo
+nSQ
 ouo
 mpW
 ouo
@@ -53542,7 +53465,7 @@ wiL
 sfr
 xpN
 qjs
-iMQ
+xpN
 tVI
 bpi
 eLo
@@ -53657,7 +53580,7 @@ umJ
 vku
 jjN
 vkt
-bnK
+nwk
 bFf
 qML
 nwk
@@ -53701,7 +53624,7 @@ lFY
 vNh
 wuo
 xBc
-wuo
+oLS
 vQF
 prB
 wuo
@@ -53894,7 +53817,7 @@ wAF
 aPa
 bEW
 kAb
-rRN
+kAb
 eVc
 aPa
 lUK
@@ -54056,7 +53979,7 @@ dWn
 aPa
 wxY
 wxY
-rsK
+wxY
 aPa
 aPa
 lUK
@@ -54218,7 +54141,7 @@ eGp
 aPa
 aPa
 aPa
-iKG
+uhX
 aPa
 aPa
 cho
@@ -54379,8 +54302,8 @@ dvI
 bJh
 aPa
 nDO
-dbr
-eVc
+wxY
+wxY
 wxY
 nDO
 cho
@@ -54523,12 +54446,12 @@ tKx
 kGm
 tKx
 tKx
-tKx
+jwb
 tKx
 tKx
 ktD
 mrX
-xFS
+mrX
 mrX
 mrX
 jgY
@@ -54549,7 +54472,7 @@ cho
 oAZ
 uOb
 xED
-kJr
+waQ
 eDD
 iEM
 van
@@ -54692,17 +54615,17 @@ lwU
 dPS
 vxA
 nze
-waQ
-waQ
+mrX
+mrX
 fjM
-kAb
-kAb
+wxY
+wxY
 bDH
 bDH
 nwB
-cPU
-kAb
-kAb
+pmO
+wxY
+wxY
 myv
 nDO
 nDO
@@ -55028,7 +54951,7 @@ aPa
 nDO
 aEG
 sau
-cXp
+fNV
 cDm
 iQO
 cho
@@ -56162,7 +56085,7 @@ iZC
 mgo
 udc
 naj
-bUZ
+tyD
 bUZ
 bUZ
 bUZ
@@ -56324,7 +56247,7 @@ iZC
 mgo
 nmk
 udc
-udc
+vJB
 mgo
 mgo
 mEg
@@ -56810,7 +56733,7 @@ iZC
 veC
 veC
 rFG
-kaw
+vPm
 ocH
 kmB
 pkm

--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -70,9 +70,6 @@
 /turf/simulated/floor/grass2,
 /area/chapel/monastery)
 "abw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-j2"
@@ -197,7 +194,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -207,19 +203,11 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/disposals)
 "aev" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/exit)
 "aew" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -370,7 +358,7 @@
 /turf/simulated/floor/outdoors/snow/snow/snow2/cryogaia,
 /area/borealis2/outdoors/grounds)
 "agF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "agQ" = (
@@ -542,15 +530,15 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -723,9 +711,6 @@
 /obj/structure/table/standard,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/stamp/qm,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor/wood,
 /area/quartermaster)
 "aoo" = (
@@ -871,7 +856,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
@@ -1058,9 +1042,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "monotile"
-	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
 "auQ" = (
 /obj/effect/floor_decal/industrial/danger{
@@ -1588,6 +1570,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "aFr" = (
@@ -1702,6 +1687,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningwing)
 "aHM" = (
@@ -1948,8 +1937,6 @@
 /area/quartermaster/foyer)
 "aMz" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Storage";
@@ -2102,25 +2089,19 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
 "aQl" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "aQv" = (
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "32-1"
 	},
@@ -2222,8 +2203,12 @@
 	req_access = list(50)
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "aRO" = (
@@ -2456,10 +2441,10 @@
 /turf/simulated/floor/outdoors/snow/snow/cryogaia,
 /area/borealis2/outdoors/exterior)
 "aVW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -2620,7 +2605,7 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "aZL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "aZS" = (
@@ -3059,12 +3044,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "bhL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -3151,8 +3130,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -3217,7 +3196,7 @@
 	c_tag = "Surgery 1";
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -3270,9 +3249,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "monotile"
-	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
 "bmW" = (
 /obj/machinery/power/apc{
@@ -3300,7 +3277,6 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light_switch{
 	name = "light switch ";
 	pixel_y = 36
@@ -3309,6 +3285,7 @@
 	id = "pr2_window_tint";
 	pixel_y = 26
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "bnR" = (
@@ -3394,16 +3371,6 @@
 	},
 /turf/simulated/floor/plating/snow/plating,
 /area/engineering/hallway)
-"bpt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/bridge)
 "bpx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -3517,12 +3484,6 @@
 /turf/simulated/open,
 /area/storage/auxillary)
 "bst" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -4118,6 +4079,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "bIv" = (
@@ -4126,6 +4090,9 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -4178,17 +4145,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_monitoring)
 "bJj" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/docking_lounge)
+/area/hallway/secondary/exit)
 "bJr" = (
 /turf/simulated/wall,
 /area/crew_quarters/heads/hop)
@@ -4223,12 +4182,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4681,10 +4634,10 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "bQo" = (
@@ -4864,8 +4817,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "bUF" = (
@@ -5007,20 +4960,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
 "bXh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/area/hallway/secondary/exit)
 "bXi" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5036,9 +4980,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bXo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /obj/machinery/light/small,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -5090,6 +5031,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "bXY" = (
@@ -5322,11 +5266,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
@@ -5480,6 +5424,12 @@
 	},
 /obj/machinery/vending/coffee{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
@@ -5740,10 +5690,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -5857,19 +5807,11 @@
 /turf/simulated/floor/tiled/white,
 /area/security/security_aid_station)
 "cmD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation Observation";
 	req_access = list(63)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/interrogation)
 "cmV" = (
@@ -5879,9 +5821,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "cmW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -6023,12 +5962,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/security)
@@ -6478,18 +6411,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"cxU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "cxZ" = (
 /turf/simulated/wall,
 /area/chapel/monastery/brew)
@@ -6570,7 +6491,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/disposals)
 "cyQ" = (
@@ -6664,9 +6584,6 @@
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "cAo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -6900,9 +6817,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/chapel/monastery/recreation)
@@ -7670,7 +7584,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled{
+	icon_state = "monotile"
+	},
 /area/engineering/workshop)
 "cVr" = (
 /obj/structure/dispenser{
@@ -7688,20 +7604,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"cVx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/bridge)
 "cVy" = (
 /obj/machinery/atmospherics/tvalve/mirrored/bypass{
 	dir = 4
@@ -8054,11 +7956,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "dcz" = (
-/obj/structure/disposalpipe/sortjunction/untagged{
-	dir = 4
-	},
-/obj/random/maintenance/cargo,
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
 /area/maintenance/bridge)
 "dcS" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -8217,12 +8116,12 @@
 	pixel_y = -32
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "dfE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = -30
@@ -8367,11 +8266,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryobs)
 "dja" = (
@@ -8581,12 +8481,12 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/snowsuit/security,
 /obj/item/clothing/shoes/boots/winter/security,
 /obj/item/device/gps/security,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/airlock)
@@ -9237,7 +9137,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/disposals)
 "dBM" = (
@@ -9351,6 +9250,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "dFP" = (
@@ -9404,9 +9304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
 "dGp" = (
@@ -9863,13 +9761,13 @@
 	req_one_access = list(19)
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -9938,6 +9836,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "dQw" = (
@@ -10001,10 +9902,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -10050,9 +9951,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/heads/chief)
@@ -10115,6 +10013,9 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/disposals)
 "dUE" = (
@@ -10330,17 +10231,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
@@ -10380,10 +10282,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
@@ -10910,7 +10812,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northeast)
 "ehd" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -10934,7 +10836,7 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -10995,6 +10897,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_processing)
 "eiP" = (
@@ -11179,13 +11082,13 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
@@ -11534,7 +11437,6 @@
 /turf/simulated/floor,
 /area/storage/emergency_storage/emergency5)
 "euJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -11737,12 +11639,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "eys" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11755,9 +11651,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "eyN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/security/checkpoint)
+/area/hallway/secondary/exit)
 "ezf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment,
@@ -11792,12 +11690,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "eAB" = (
@@ -11996,9 +11890,6 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12009,6 +11900,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -12100,12 +11994,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12126,8 +12014,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance/sec{
 	name = "Security Maintenance";
 	req_access = list(63);
@@ -12154,13 +12040,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
 "eIG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
 "eJe" = (
 /obj/item/weapon/stool/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "eJt" = (
@@ -12204,6 +12093,9 @@
 	id_tag = "arrivals_dock";
 	pixel_y = -25;
 	req_one_access = list(13)
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -12529,15 +12421,10 @@
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "eQE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/quartermaster)
 "eRd" = (
@@ -12652,14 +12539,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/exit_link)
 "eTL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/turf/simulated/wall/r_wall,
-/area/security/pilotroom)
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
 "eTW" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -12767,12 +12651,6 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "eUY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -12807,7 +12685,6 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
 "eVw" = (
@@ -12924,12 +12801,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "eYw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -12971,16 +12848,16 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "eZf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
@@ -13337,12 +13214,6 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
@@ -13350,6 +13221,12 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -13403,8 +13280,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "fiQ" = (
@@ -13645,12 +13522,6 @@
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds)
 "fns" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 8
 	},
@@ -14473,7 +14344,7 @@
 "fDq" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/corner/lime/full,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -14646,6 +14517,9 @@
 "fGW" = (
 /obj/structure/urinal{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
@@ -14884,6 +14758,9 @@
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "fMi" = (
@@ -15049,8 +14926,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/chapel/monastery/recreation)
@@ -15170,9 +15047,6 @@
 /area/hallway/primary/starboard)
 "fRc" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "fRm" = (
@@ -15333,6 +15207,9 @@
 	name = "Common Channel";
 	pixel_x = 21
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/engineering/drone_fabrication)
 "fUd" = (
@@ -15410,10 +15287,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/security/airlock)
 "fVg" = (
@@ -15433,15 +15310,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
-"fVw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "fVx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16020,7 +15888,9 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Den"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	icon_state = "monotile"
+	},
 /area/engineering/workshop)
 "gfp" = (
 /obj/structure/table/reinforced,
@@ -16098,9 +15968,6 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "ghi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -16118,6 +15985,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/paleblue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -16744,11 +16614,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "gta" = (
@@ -16907,7 +16779,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -16996,18 +16868,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
-"gxW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/quartermaster)
 "gyk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17088,16 +16948,14 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "gzV" = (
@@ -17248,6 +17106,9 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
@@ -17423,8 +17284,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "gGS" = (
@@ -17619,6 +17480,9 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
 "gNz" = (
@@ -17703,6 +17567,12 @@
 	req_one_access = list(51,52)
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/pilotroom)
 "gOq" = (
@@ -17746,10 +17616,8 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
 "gOL" = (
@@ -17814,11 +17682,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/lobby)
 "gPF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "gQc" = (
@@ -17864,9 +17730,6 @@
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds)
 "gRy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
 "gRG" = (
@@ -18014,9 +17877,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -18182,6 +18042,12 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -18359,12 +18225,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "hcm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -18373,6 +18233,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
@@ -18404,12 +18270,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "hdm" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/teleporter)
+/area/hallway/secondary/exit)
 "hdu" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -18425,6 +18289,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "hdC" = (
@@ -18456,6 +18322,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -18532,11 +18401,14 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "hfF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/workshop)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/monastery)
 "hfK" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18954,12 +18826,15 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -19234,8 +19109,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -19296,6 +19171,9 @@
 	},
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "hvr" = (
@@ -19334,11 +19212,22 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "hwR" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/monastery)
 "hxd" = (
 /turf/simulated/wall,
 /area/maintenance/research_port)
@@ -19420,9 +19309,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery)
@@ -20498,10 +20384,7 @@
 	req_access = list(31);
 	req_one_access = list()
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/office)
 "hUa" = (
@@ -20582,12 +20465,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_aft)
 "hVF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/southeast)
@@ -20670,9 +20553,11 @@
 /area/security/outpost)
 "hXG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
@@ -20733,16 +20618,13 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
 /obj/effect/floor_decal/rust,
 /obj/structure/disposaloutlet,
 /turf/simulated/floor,
 /area/quartermaster/disposals)
 "hYs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
@@ -20802,7 +20684,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -21200,8 +21081,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -21458,10 +21341,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -21920,10 +21803,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "iAE" = (
@@ -22104,10 +21983,10 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -22245,6 +22124,12 @@
 "iFA" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
 "iFL" = (
@@ -22256,14 +22141,18 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/red/full{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
@@ -22339,6 +22228,9 @@
 /area/civilian/atrium/central)
 "iHG" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "iHO" = (
@@ -22478,12 +22370,6 @@
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "iLf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22712,11 +22598,11 @@
 /turf/simulated/wall/titanium,
 /area/borealis2/outdoors/grounds/checkpoint)
 "iPw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/monastery)
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
 "iPQ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -22890,6 +22776,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/lab)
 "iUP" = (
@@ -23610,6 +23497,9 @@
 	dir = 5
 	},
 /obj/structure/stairs/spawner/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningwing)
 "jmo" = (
@@ -23810,9 +23700,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "joV" = (
@@ -23927,6 +23814,9 @@
 /area/borealis2/outdoors/exterior)
 "jrF" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -24201,14 +24091,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/junction{
 	dir = 2;
 	icon_state = "pipe-j2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -24650,12 +24539,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -24663,6 +24546,8 @@
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/rnd/hallway)
 "jFG" = (
@@ -24884,9 +24769,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -24939,7 +24821,7 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -24962,7 +24844,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/secondary/exit)
 "jLc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "jLU" = (
@@ -25188,18 +25071,12 @@
 /turf/simulated/floor/tiled/yellow,
 /area/chapel/monastery/kitchen)
 "jRC" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "jRF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -25210,6 +25087,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "jRK" = (
@@ -25240,9 +25118,6 @@
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25266,7 +25141,6 @@
 "jSi" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 1
 	},
@@ -25450,12 +25324,6 @@
 /obj/machinery/door/airlock/glass_mining{
 	name = "Mining Operations"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -25565,14 +25433,15 @@
 /turf/simulated/floor/tiled/yellow,
 /area/chapel/monastery/kitchen)
 "jYY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/suit/storage/hooded/wintercoat/snowsuit,
+/obj/item/clothing/shoes/boots/winter,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/hangar)
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/exit)
 "jZh" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -25610,17 +25479,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "jZT" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/blue,
+/obj/effect/floor_decal/corner/white{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/hallway/secondary/entry/docking_lounge)
 "kaa" = (
 /obj/structure/table/standard,
 /obj/item/weapon/hand_tele,
@@ -25922,13 +25787,13 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
@@ -25976,14 +25841,14 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaymain)
 "khe" = (
@@ -25991,7 +25856,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "khl" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -26024,7 +25889,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -26175,9 +26039,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -26297,7 +26158,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled{
+	icon_state = "monotile"
+	},
 /area/engineering/workshop)
 "knW" = (
 /obj/effect/floor_decal/corner_oldtile/purple{
@@ -26369,11 +26232,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "kpa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/entry/docking_lounge)
 "kpt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26497,6 +26358,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
 "kqY" = (
@@ -26757,16 +26619,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "kvD" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack/shelf,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/clothing/suit/storage/hooded/wintercoat/snowsuit,
-/obj/item/clothing/shoes/boots/winter,
-/obj/item/weapon/ice_pick,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/entry/docking_lounge)
 "kvG" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -27244,6 +27104,9 @@
 	c_tag = "Monastary Entry Port";
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery)
 "kFu" = (
@@ -27276,10 +27139,14 @@
 /obj/machinery/camera/network/cargo{
 	c_tag = "Staircase Lower"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningwing)
 "kGv" = (
 /obj/structure/bed/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "kGA" = (
@@ -27491,11 +27358,6 @@
 /turf/simulated/floor/tiled/yellow,
 /area/chapel/monastery/kitchen)
 "kLz" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1380;
-	id_tag = "escape_dock_south_starboard_pump"
-	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "escape_dock_south_starboard_sensor";
@@ -27590,7 +27452,9 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "kNy" = (
@@ -27681,13 +27545,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "kOA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/white{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "kOT" = (
@@ -27729,10 +27591,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
 "kPL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "kPY" = (
@@ -27824,10 +27684,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
@@ -28168,9 +28025,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "lak" = (
@@ -28347,6 +28201,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "lei" = (
@@ -28480,10 +28336,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/item/device/sleevemate,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/item/device/sleevemate,
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
 "lgK" = (
@@ -28586,6 +28442,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "lje" = (
@@ -28667,8 +28524,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "llN" = (
@@ -28792,6 +28649,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -29063,19 +28923,11 @@
 /turf/simulated/open,
 /area/engineering/hallway)
 "luc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/atrium/central)
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "lup" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/fans/tiny{
@@ -29091,10 +28943,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/airlock)
@@ -29209,12 +29061,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "lvE" = (
@@ -29300,7 +29148,6 @@
 	},
 /obj/item/weapon/folder/white,
 /obj/item/weapon/folder/white,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/pink{
 	dir = 9
 	},
@@ -29491,10 +29338,10 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "lBk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/airlock)
 "lBo" = (
@@ -29550,15 +29397,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	name = "Drone Fabrication";
 	sortType = "Drone Fabrication"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "lCs" = (
@@ -29615,16 +29460,12 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_smes)
 "lEC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "lES" = (
@@ -30015,9 +29856,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "lMg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -30028,6 +29866,9 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "lMt" = (
@@ -30326,10 +30167,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "lRL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -30368,12 +30209,6 @@
 /area/security/nuke_storage)
 "lSF" = (
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
@@ -30535,14 +30370,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "lVx" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
+/area/medical/reception)
 "lVJ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	frequency = 1379;
@@ -30651,6 +30486,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "lZl" = (
@@ -30680,12 +30516,10 @@
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hallway)
 "lZO" = (
@@ -30853,9 +30687,6 @@
 /turf/simulated/floor,
 /area/quartermaster/disposals)
 "mdi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
 	id_tag = "escape_dock_snorth_airlock";
@@ -30875,6 +30706,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/hallway/secondary/exit)
@@ -31322,9 +31156,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "mmC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
 	},
@@ -31544,12 +31375,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/southwest)
 "mrb" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/locker)
+/area/hallway/primary/central_one)
 "mrd" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass2,
@@ -31756,17 +31585,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "muF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/hallway/secondary/entry/docking_lounge)
+/area/hallway/primary/central_one)
 "mvt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -31930,12 +31762,12 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/white{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -32018,6 +31850,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -32414,9 +32249,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "mFC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/floor_decal/rust/mono_rusted2,
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -32427,6 +32259,9 @@
 	opacity = 0
 	},
 /obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -32474,6 +32309,12 @@
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
@@ -33008,8 +32849,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "mOC" = (
@@ -33170,7 +33013,6 @@
 /obj/structure/disposalpipe/sortjunction/wildcard/flipped{
 	dir = 4
 	},
-/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "mRg" = (
@@ -33742,14 +33584,15 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "nbE" = (
-/obj/structure/bed/chair{
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgeryobs)
+/turf/simulated/floor/tiled/steel,
+/area/civilian/atrium/central)
 "nbG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33802,6 +33645,7 @@
 	dir = 4
 	},
 /obj/structure/toilet,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
 "ncQ" = (
@@ -34162,9 +34006,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "njs" = (
@@ -34218,6 +34059,9 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "nkh" = (
@@ -34261,9 +34105,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "nlk" = (
@@ -34590,6 +34433,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "nrn" = (
@@ -34678,15 +34522,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 25
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
 "ntW" = (
@@ -34815,6 +34655,9 @@
 "nvX" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "nwj" = (
@@ -35468,6 +35311,8 @@
 /area/maintenance/substation/engineering)
 "nJx" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "nJA" = (
@@ -35600,6 +35445,12 @@
 	name = "Station Intercom (Security)";
 	pixel_y = -21
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
 "nMU" = (
@@ -35682,6 +35533,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "nNV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hop)
 "nNW" = (
@@ -35760,9 +35614,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery)
 "nPO" = (
@@ -35902,15 +35754,15 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -36008,10 +35860,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "nUN" = (
@@ -36058,9 +35910,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "nVo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/southeast)
@@ -36456,13 +36305,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
 "odi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
@@ -36577,9 +36426,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -36632,17 +36478,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "ohx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/chapel/monastery)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/civilian/atrium/central)
 "ohO" = (
 /obj/machinery/shower{
 	dir = 1
@@ -36901,9 +36742,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/scanning)
 "ont" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -36922,6 +36760,9 @@
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medbay Primary Hallway";
 	req_one_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -37065,7 +36906,6 @@
 /turf/simulated/wall/rshull,
 /area/shuttle/security)
 "osB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
 	id_tag = "escape_dock_ssouth_airlock";
@@ -37082,6 +36922,9 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -37147,11 +36990,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "otl" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1380;
-	id_tag = "escape_dock_north_starboard_pump"
-	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "escape_dock_north_starboard_sensor";
@@ -37206,7 +37044,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "ouo" = (
@@ -37280,8 +37118,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "ovr" = (
@@ -37355,6 +37193,7 @@
 /area/engineering/hallway)
 "owy" = (
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "owQ" = (
@@ -37556,18 +37395,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
-"ozO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/research_starboard)
 "ozR" = (
 /obj/machinery/computer/secure_data/detective_computer{
 	dir = 1
@@ -37784,7 +37611,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
@@ -37976,6 +37802,7 @@
 "oJo" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/exit)
 "oJx" = (
@@ -38039,7 +37866,7 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -38051,6 +37878,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "oLX" = (
@@ -38155,6 +37983,12 @@
 	pixel_x = -21;
 	pixel_y = 22;
 	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
@@ -38618,13 +38452,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/airlock)
 "oWD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -38677,6 +38511,8 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "oWZ" = (
@@ -38700,9 +38536,6 @@
 /turf/simulated/floor/plating/snow/plating/cryogaia,
 /area/borealis2/outdoors/grounds)
 "oXx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 8
 	},
@@ -38831,6 +38664,9 @@
 	},
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -39058,16 +38894,16 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "pem" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -39726,15 +39562,13 @@
 /turf/simulated/floor/outdoors/snow/snow/snow2/cryogaia,
 /area/borealis2/outdoors/grounds/wall)
 "ppm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
@@ -40004,6 +39838,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "puJ" = (
@@ -40152,6 +39989,7 @@
 /area/crew_quarters/kitchen)
 "pxe" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "pxh" = (
@@ -40285,6 +40123,8 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "pAk" = (
@@ -40568,6 +40408,12 @@
 /obj/machinery/door/airlock{
 	id_tag = "05researchtoliet1";
 	name = "Unit 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
@@ -40928,10 +40774,10 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "pOl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/security/airlock)
 "pOo" = (
@@ -40959,10 +40805,10 @@
 /turf/simulated/wall,
 /area/chapel/monastery)
 "pQt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/camera/motion/command{
 	c_tag = "Teleporter (Motion)"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "pQO" = (
@@ -41262,6 +41108,8 @@
 "pWl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "pWE" = (
@@ -41314,14 +41162,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor,
 /area/engineering/drone_fabrication)
-"pXI" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/locker)
 "pXP" = (
 /obj/machinery/power/terminal,
 /obj/effect/floor_decal/industrial/warning,
@@ -41450,9 +41290,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "qby" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
 	d1 = 1;
@@ -42607,9 +42444,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "qAq" = (
@@ -42898,11 +42732,11 @@
 /turf/simulated/wall,
 /area/security/armoury)
 "qFs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
@@ -42962,9 +42796,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "qFZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 8
 	},
@@ -43019,6 +42850,9 @@
 /area/medical/resleeving)
 "qGy" = (
 /mob/living/simple_mob/animal/passive/dog/corgi/Lisa,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/quartermaster)
 "qGP" = (
@@ -43039,9 +42873,6 @@
 /obj/item/device/flashlight/lamp/green{
 	pixel_x = -10;
 	pixel_y = 12
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -43071,6 +42902,12 @@
 /obj/machinery/microwave,
 /obj/effect/floor_decal/corner/red{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
@@ -43135,10 +42972,10 @@
 	name = "light switch ";
 	pixel_y = 36
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "qJn" = (
@@ -43661,12 +43498,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43913,11 +43744,12 @@
 /turf/simulated/floor/outdoors/snow/snow/cryogaia,
 /area/borealis2/outdoors/exterior)
 "qYH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/deployable/barrier,
-/turf/simulated/floor/tiled/red,
-/area/security/security_equiptment_storage)
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/civilian/atrium/central)
 "qYN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -43994,9 +43826,6 @@
 /turf/simulated/floor,
 /area/maintenance/substation/civilian)
 "raS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
@@ -44139,7 +43968,6 @@
 	req_one_access = list(52,58)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/red,
 /area/crew_quarters/heads/hos)
@@ -44352,12 +44180,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44392,7 +44214,7 @@
 /area/borealis2/outdoors/grounds/tower/southeast)
 "rjk" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -44421,9 +44243,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "rko" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -44438,6 +44257,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -44755,20 +44577,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaymain)
 "rrD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/workshop)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/heads/hos)
 "rrP" = (
 /obj/machinery/conveyor{
 	dir = 3;
 	id = "packageSort1"
 	},
-/obj/structure/plasticflaps/mining,
 /turf/simulated/floor{
 	dir = 1
 	},
@@ -45003,17 +44822,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "rwy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/locker)
+/turf/simulated/floor/tiled/dark,
+/area/security/hangar)
 "rwz" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/steel,
@@ -45048,10 +44868,6 @@
 	},
 /turf/simulated/floor,
 /area/storage/tech)
-"rxp" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/quartermaster/disposals)
 "rxv" = (
 /obj/machinery/door/window/brigdoor/southleft,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45242,12 +45058,6 @@
 /obj/machinery/door/airlock/maintenance/rnd{
 	name = "Science Maintenance"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -45287,7 +45097,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "rCk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "rCl" = (
@@ -45382,14 +45192,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "rDr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel,
-/area/security/pilotroom)
+/turf/simulated/floor/tiled/dark,
+/area/security/hangar)
 "rDv" = (
 /turf/simulated/wall,
 /area/security/airlock)
@@ -45403,11 +45213,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "rDG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/engineering/drone_fabrication)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/southeast)
 "rEf" = (
 /turf/simulated/floor/outdoors/snow/snow/cryogaia/covered,
 /area/borealis2/outdoors/grounds)
@@ -45504,7 +45319,6 @@
 /obj/machinery/camera/network/prison{
 	c_tag = "Brig Cell 1"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "rFI" = (
@@ -45640,9 +45454,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer";
 	req_access = newlist();
@@ -45659,13 +45470,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/tiled{
+	icon_state = "monotile"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "rJG" = (
 /obj/structure/bed/chair/comfy/brown,
@@ -45734,16 +45541,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "rMA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/ash,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/foyer)
+/area/hallway/primary/starboard)
 "rMD" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -46107,6 +45915,8 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "rSh" = (
@@ -46233,6 +46043,9 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgeryprep)
 "rUZ" = (
@@ -46273,9 +46086,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbaymain)
 "rVT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -46528,7 +46338,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/airlock)
 "sce" = (
@@ -47049,6 +46859,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
 "smw" = (
@@ -47448,11 +47261,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "suv" = (
@@ -47504,20 +47317,17 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/weapon/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/weapon/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical Storage"
 	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "sve" = (
@@ -48083,7 +47893,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/airlock)
 "sFZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "sGl" = (
@@ -48138,15 +47950,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
@@ -48231,10 +48043,6 @@
 "sId" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /obj/item/device/geiger/wall{
 	dir = 4;
@@ -48657,6 +48465,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery)
 "sTa" = (
@@ -48920,6 +48731,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "taS" = (
@@ -49008,12 +48822,6 @@
 	req_one_access = list()
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49495,9 +49303,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	icon_state = "monotile"
-	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
 "tmi" = (
 /obj/machinery/door/firedoor/glass,
@@ -49526,7 +49332,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/east)
 "tnK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -49539,9 +49345,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/warden)
 "toA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -49655,16 +49458,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/ert_arrival)
 "tqo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/random/maintenance/cargo,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "tqv" = (
@@ -49881,7 +49684,6 @@
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light_switch{
 	name = "light switch ";
 	pixel_y = 36
@@ -49890,6 +49692,7 @@
 	id = "pr1_window_tint";
 	pixel_y = 26
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "twc" = (
@@ -50373,16 +50176,12 @@
 	name = "Pill Cabinet";
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/pink{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "tEa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/shieldgen,
 /obj/machinery/camera/network/engineering{
@@ -50888,9 +50687,10 @@
 /area/crew_quarters/heads/hop)
 "tPl" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "tPm" = (
@@ -51109,6 +50909,7 @@
 /area/crew_quarters/heads/chief)
 "tTH" = (
 /obj/effect/floor_decal/corner/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/docking_lounge)
 "tTP" = (
@@ -51123,13 +50924,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "tTV" = (
@@ -51160,17 +50961,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
 "tUw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -51181,6 +50981,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "tUV" = (
@@ -51189,6 +50992,9 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
@@ -51275,6 +51081,7 @@
 /obj/machinery/shower{
 	pixel_y = 3
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
 "tXX" = (
@@ -51883,7 +51690,9 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "uqV" = (
@@ -51972,6 +51781,8 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "usR" = (
@@ -52043,13 +51854,6 @@
 	},
 /turf/simulated/floor/outdoors/snow/gravsnow/cryogaia,
 /area/borealis2/outdoors/grounds)
-"uvs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall,
-/area/maintenance/bridge)
 "uvG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52098,12 +51902,6 @@
 /area/security/briefing_room)
 "uwH" = (
 /obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -52238,13 +52036,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
-"uAe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall,
-/area/quartermaster/disposals)
 "uAt" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -53005,6 +52796,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
 "uQq" = (
@@ -53071,12 +52863,6 @@
 "uRY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53203,12 +52989,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -53268,6 +53048,7 @@
 /area/medical/surgery)
 "uVm" = (
 /obj/structure/transit_tube/station,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery)
 "uVA" = (
@@ -53316,9 +53097,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "uWN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -53328,6 +53106,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningwing)
 "uWY" = (
@@ -53521,10 +53301,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
@@ -54001,9 +53781,10 @@
 /area/medical/cryo)
 "vnX" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "vnY" = (
 /obj/structure/cable{
@@ -54034,7 +53815,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/disposals)
 "voa" = (
@@ -54100,17 +53880,15 @@
 /turf/simulated/floor/outdoors/snow/gravsnow/cryogaia,
 /area/borealis2/outdoors/exterior)
 "voN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/steel,
-/area/security/pilotroom)
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "voQ" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54142,10 +53920,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
 "vpD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -54156,13 +53934,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating,
 /area/maintenance/bridge)
 "vpQ" = (
@@ -54172,6 +53953,9 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/borealis2/elevator/scicargo)
@@ -54302,15 +54086,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/office)
@@ -54504,9 +54279,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -54517,6 +54289,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -54553,10 +54328,10 @@
 /area/shuttle/security)
 "vxP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -54785,12 +54560,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/security/detectives_office)
 "vDb" = (
@@ -54838,6 +54607,12 @@
 /turf/simulated/wall/titanium,
 /area/borealis2/outdoors/grounds/wall)
 "vDv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/hangar)
 "vDS" = (
@@ -54859,6 +54634,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/hallway/secondary/exit)
 "vEa" = (
@@ -55137,7 +54915,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/cargo{
 	c_tag = "Trash Chute";
 	dir = 4;
@@ -55711,12 +55488,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
-"vWR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "vWX" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -55726,10 +55497,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
@@ -55925,7 +55696,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster)
@@ -56004,9 +55775,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/assembly/chargebay)
 "wbU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark{
 	name = "lightsout"
 	},
@@ -56150,11 +55918,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Surgery Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
@@ -56235,10 +56003,10 @@
 /turf/simulated/floor/plating,
 /area/constructionsite/cryogaia)
 "whh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/southeast)
 "whq" = (
@@ -56257,12 +56025,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "whS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/quartermaster)
 "wic" = (
 /mob/living/simple_mob/animal/sif/savik,
 /turf/simulated/floor/outdoors/snow/snow/cryogaia,
@@ -56551,6 +56316,9 @@
 	name = "Common Channel";
 	pixel_y = -21
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "wmb" = (
@@ -56608,7 +56376,9 @@
 /area/shuttle/security)
 "wmT" = (
 /obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "wnm" = (
@@ -56804,7 +56574,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/medical/medbay_primary_storage)
 "wqF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "wqH" = (
@@ -57058,9 +56830,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/chapel/monastery/recreation)
 "wwr" = (
@@ -57238,6 +57007,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery)
 "wzD" = (
@@ -57548,13 +57320,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
-"wFk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall,
-/area/maintenance/bridge)
 "wFs" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -57579,14 +57344,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "wGm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/miningwing)
@@ -57828,15 +57593,12 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
 "wKd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57930,10 +57692,6 @@
 /obj/machinery/door/airlock/maintenance/medical{
 	req_one_access = list(52,64)
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -58233,6 +57991,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/monastery/recreation)
 "wRm" = (
@@ -58341,16 +58102,18 @@
 /obj/machinery/conveyor{
 	id = "packageSort1"
 	},
-/obj/structure/plasticflaps/mining,
+/obj/structure/plasticflaps,
 /turf/simulated/floor{
 	dir = 1
 	},
 /area/quartermaster/disposals)
 "wTU" = (
 /obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
@@ -59221,6 +58984,9 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint)
 "xnd" = (
@@ -59242,9 +59008,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -59262,6 +59025,9 @@
 /obj/machinery/alarm{
 	frequency = 1441;
 	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay3)
@@ -59323,15 +59089,13 @@
 "xoH" = (
 /obj/effect/floor_decal/corner_oldtile/purple,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner_oldtile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "xoQ" = (
@@ -59340,10 +59104,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -59785,16 +59549,16 @@
 /turf/simulated/floor/plating/snow/plating,
 /area/borealis2/outdoors/grounds/tower/northeast)
 "xyF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
@@ -59894,13 +59658,17 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/central)
 "xAh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/shieldgen,
-/turf/simulated/floor,
-/area/engineering/storage)
+/obj/effect/floor_decal/corner_oldtile/purple{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/starboard)
 "xAt" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -60000,8 +59768,11 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -60035,6 +59806,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/research)
 "xEv" = (
@@ -60372,11 +60144,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/secondary/exit)
 "xMd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/floor_decal/corner_oldtile/gray/diagonal{
+	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/rnd/rdoffice)
 "xMo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/yellow{
@@ -60596,10 +60369,6 @@
 /obj/effect/landmark/start{
 	name = "Command Secretary"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -60656,6 +60425,12 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/security/pilotroom)
 "xRG" = (
@@ -60703,20 +60478,16 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "xSp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/starboard)
+/area/crew_quarters/locker)
 "xSv" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
@@ -60737,9 +60508,6 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "xSC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "xSF" = (
@@ -61029,6 +60797,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/miningwing)
 "xYT" = (
@@ -61185,9 +60955,6 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/security/hallway)
@@ -61234,16 +61001,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	name = "QM Office";
 	sortType = "QM Office"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "ydL" = (
@@ -61571,12 +61334,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
-"yiD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "yiT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -61710,10 +61467,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/security/briefing_room)
 "ykY" = (
@@ -66663,7 +66418,7 @@ wZT
 wZT
 wZT
 gOH
-wZT
+rwy
 mef
 wZT
 vtW
@@ -66824,8 +66579,8 @@ aXq
 kno
 kno
 kno
-jYY
 kno
+rDr
 kno
 kno
 odf
@@ -67148,7 +66903,7 @@ wOo
 nzL
 pWc
 nzL
-eTL
+wOo
 gOn
 lyo
 lyo
@@ -67310,7 +67065,7 @@ pts
 xnn
 tPY
 epd
-voN
+xnn
 iFA
 lyo
 sFW
@@ -67472,7 +67227,7 @@ ehj
 ehj
 ehj
 ehj
-rDr
+ehj
 qHx
 lyo
 kvG
@@ -67510,7 +67265,7 @@ xIW
 vYN
 toE
 tEa
-xAh
+kyO
 kQr
 rkq
 rkq
@@ -67634,7 +67389,7 @@ tuL
 ehj
 byF
 ehj
-rDr
+ehj
 xRE
 lyo
 ful
@@ -67796,7 +67551,7 @@ ujS
 mQt
 nDP
 ehj
-rDr
+ehj
 cfJ
 bmi
 lyo
@@ -67958,7 +67713,7 @@ ujS
 ehj
 cWp
 ehj
-rDr
+ehj
 nMN
 bmi
 wea
@@ -68434,7 +68189,7 @@ tVE
 ckV
 omA
 puB
-vWR
+xSC
 vkZ
 omA
 llp
@@ -68929,7 +68684,7 @@ bUK
 bUK
 chb
 bnZ
-qnU
+rrD
 sMI
 wNF
 qGR
@@ -70217,7 +69972,7 @@ pjw
 jHK
 sjY
 enI
-lVx
+ktK
 ktK
 iNu
 sjY
@@ -70251,7 +70006,7 @@ bVG
 vfP
 tGV
 gnQ
-qYH
+gnQ
 uoM
 iKh
 vgT
@@ -70477,7 +70232,7 @@ iSE
 ihD
 vaU
 vaU
-toM
+vaU
 vaU
 vaU
 cnc
@@ -70541,7 +70296,7 @@ alo
 aTe
 sjY
 ylt
-nbE
+eRd
 eRd
 qEN
 sjY
@@ -70801,7 +70556,7 @@ iSE
 ihD
 vaU
 vaU
-vaU
+toM
 vaU
 vaU
 cnc
@@ -71470,15 +71225,15 @@ cVz
 ktx
 nTx
 sMp
-nTx
-nTx
-nTx
-nTx
-nTx
-nTx
-nTx
-nTx
-nTx
+aev
+bJj
+bXh
+bJj
+bJj
+bJj
+bJj
+bJj
+iPw
 kfd
 iDm
 nTx
@@ -71724,7 +71479,7 @@ mPH
 uXL
 gzr
 tTQ
-bXh
+skN
 rLC
 gzX
 iGs
@@ -71958,7 +71713,7 @@ kuw
 akb
 oqG
 jQP
-nTx
+eyN
 pWE
 lJd
 lJd
@@ -72120,12 +71875,12 @@ cVz
 cVz
 bBH
 dMT
-nTx
+eTL
 lYX
-iHG
+hdm
 oJo
-iHG
-iHG
+hdm
+hdm
 jRF
 alI
 nbQ
@@ -72454,7 +72209,7 @@ plY
 gbo
 cVz
 jQt
-dvN
+jYY
 jQt
 cVz
 hRN
@@ -72778,7 +72533,7 @@ tfn
 oKn
 kpT
 nTx
-kpa
+uOx
 gHQ
 cVz
 qrW
@@ -72795,7 +72550,7 @@ svS
 vab
 kPL
 ppm
-srN
+luc
 yhW
 aTX
 qYb
@@ -72940,7 +72695,7 @@ vDS
 pxt
 cVz
 dvN
-kvD
+jQt
 dvN
 cVz
 rSt
@@ -72955,7 +72710,7 @@ kug
 kuz
 kkT
 fWf
-xMd
+srN
 iko
 hsH
 wOv
@@ -73603,9 +73358,9 @@ eqn
 pZE
 cwY
 cxb
-srN
+aTX
 ccQ
-hsH
+lVx
 saX
 wvG
 qCK
@@ -73765,7 +73520,7 @@ cwY
 cwY
 jQF
 xky
-yiD
+srN
 iAy
 hsH
 afE
@@ -73922,13 +73677,13 @@ kKu
 qjM
 mYn
 oMs
-bJj
+edx
 jJe
 xxC
 bxZ
 ffg
-hwR
-cxU
+srN
+iAy
 ixB
 nQu
 pbM
@@ -73939,7 +73694,7 @@ nDG
 wIi
 lBo
 aoC
-fVu
+ddl
 ejC
 hXe
 mFm
@@ -73998,7 +73753,7 @@ vXI
 rLH
 fVy
 rLH
-rDG
+rLH
 oQw
 gWY
 hxd
@@ -74084,8 +73839,8 @@ kUr
 kUr
 kUr
 kUr
-muF
-uqY
+kUr
+kvD
 eJC
 xol
 wFR
@@ -74101,7 +73856,7 @@ foC
 cEi
 kNs
 mFm
-luc
+mFm
 jgK
 nqQ
 eWF
@@ -74146,7 +73901,7 @@ amD
 amD
 rQg
 tvJ
-rMA
+lhC
 hcm
 uWY
 eKo
@@ -74226,9 +73981,9 @@ ssM
 rSp
 ouj
 uqw
-eyN
-eyN
-eyN
+pmc
+pmc
+pmc
 jRC
 pjI
 qgC
@@ -74246,13 +74001,13 @@ kUr
 gVw
 kUr
 kUr
-muF
+kUr
 uqY
 nlU
 qAt
 nDG
 nDG
-xPF
+sGz
 nDG
 nDG
 isL
@@ -74261,7 +74016,7 @@ yjq
 gIp
 pls
 dyV
-hfp
+nbE
 hfp
 hfp
 hfp
@@ -74423,7 +74178,7 @@ krO
 mKd
 dgz
 gXw
-moz
+xvB
 ibu
 ibu
 hfp
@@ -74582,10 +74337,10 @@ ffA
 qhC
 sRj
 qFs
-nDG
-pls
-nDG
-moz
+mrb
+muF
+mrb
+ohx
 cCy
 sZN
 hfp
@@ -74726,11 +74481,11 @@ cOH
 xol
 jOc
 myu
-tce
+jZT
 dFj
 jrF
 owy
-kUr
+kpa
 tTH
 kOA
 tlR
@@ -74909,7 +74664,7 @@ oNF
 bqQ
 npW
 sGz
-hfp
+qYH
 hfp
 hfp
 hfp
@@ -75771,8 +75526,8 @@ yeb
 rCk
 vpD
 wqF
-rrD
-hfF
+btf
+bhj
 cjI
 cUR
 kEr
@@ -76822,7 +76577,7 @@ uDf
 uDf
 pPH
 uVm
-aZS
+hfF
 pPH
 uDf
 xxL
@@ -76984,7 +76739,7 @@ uDf
 uDf
 pPH
 pPH
-iPw
+vAL
 pPH
 etu
 pPH
@@ -77048,7 +76803,7 @@ eZX
 qVD
 ykC
 ivX
-aev
+dPw
 qFZ
 fBX
 xhz
@@ -77210,7 +76965,7 @@ biq
 eMW
 fcG
 nBV
-bkJ
+rMA
 bIv
 mac
 kYL
@@ -77389,7 +77144,7 @@ brs
 weG
 jxx
 oCK
-hHj
+xMd
 kYT
 hHj
 pSN
@@ -78281,7 +78036,7 @@ uDf
 uDf
 etu
 rqM
-vQL
+hwR
 tOH
 jmM
 kLu
@@ -78379,7 +78134,7 @@ jqu
 eXJ
 mRQ
 lzM
-ozO
+wKd
 wHh
 qzq
 rEf
@@ -78661,7 +78416,7 @@ pIr
 rrz
 whh
 hVF
-wVD
+rDG
 lOk
 aGE
 jrw
@@ -79006,7 +78761,7 @@ gJr
 pwp
 ttj
 sYF
-dAR
+xAh
 jTL
 dAR
 xOB
@@ -79094,7 +78849,7 @@ cUp
 ash
 ash
 ash
-ohx
+ash
 ash
 iWE
 fbm
@@ -79328,7 +79083,7 @@ qKD
 dQs
 fFt
 vPk
-xSp
+ubT
 viI
 ndf
 pHa
@@ -79479,7 +79234,7 @@ vQh
 red
 kdI
 gzJ
-qPc
+voN
 fDL
 ipD
 jBS
@@ -79507,13 +79262,13 @@ anR
 juF
 hrN
 wEa
-wEa
+xSp
 uUj
 vgX
+xSp
 wEa
 wEa
-wEa
-rwy
+sUN
 fam
 fyP
 xey
@@ -79608,17 +79363,17 @@ aJz
 jFI
 ovd
 fiK
-bpt
-bpt
-bpt
-bpt
-bpt
-bpt
+mux
+mux
+mux
+mux
+mux
+mux
 stE
-bpt
-bpt
-bpt
-bpt
+mux
+mux
+mux
+mux
 bUj
 vWX
 aQA
@@ -79652,7 +79407,7 @@ aoc
 plt
 nti
 iNv
-gxW
+iLf
 aom
 xKQ
 orq
@@ -79675,7 +79430,7 @@ jnQ
 eJe
 wEa
 wEa
-rwy
+sUN
 ewA
 gQI
 lLZ
@@ -79809,7 +79564,7 @@ tQI
 jBS
 qAm
 euJ
-whS
+rkF
 rkF
 iht
 iSU
@@ -79831,7 +79586,7 @@ anR
 juF
 sKo
 snP
-pXI
+wTU
 qkq
 txE
 wTU
@@ -79947,7 +79702,7 @@ xbv
 dYy
 mux
 mux
-cVx
+stE
 mux
 mux
 mux
@@ -79958,7 +79713,7 @@ wZI
 pQt
 aVW
 sFZ
-hdm
+xfE
 wpo
 wZI
 mZf
@@ -79969,7 +79724,7 @@ aPl
 qKD
 nQm
 nYn
-fVw
+qAm
 jBF
 taX
 jBS
@@ -79996,7 +79751,7 @@ wEa
 xtd
 pBb
 uUj
-mrb
+xtd
 wEa
 gHf
 nLs
@@ -80139,7 +79894,7 @@ lIy
 nti
 qNf
 iLf
-xKQ
+whS
 xKQ
 cnD
 nti
@@ -80926,8 +80681,8 @@ usR
 qNF
 khe
 tPl
-rxp
-uAe
+jdz
+jdz
 vSR
 qDB
 cdb
@@ -80954,7 +80709,7 @@ uRb
 oqx
 sjL
 mmC
-wGm
+hrX
 oFS
 jRc
 msG
@@ -81085,7 +80840,7 @@ usR
 usR
 usR
 usR
-usR
+qNF
 vnX
 dcz
 hYk
@@ -81108,7 +80863,7 @@ cRV
 aKH
 aKH
 aKH
-jZT
+aKH
 pRt
 pRt
 akZ
@@ -81247,9 +81002,9 @@ usR
 usR
 usR
 usR
-usR
-uvs
-wFk
+qNF
+qNF
+qNF
 jdz
 jdz
 dUl

--- a/maps/yw/cryogaia-06-upper.dmm
+++ b/maps/yw/cryogaia-06-upper.dmm
@@ -1829,7 +1829,7 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "ei" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/excursion_dock)
 "ej" = (
@@ -1871,7 +1871,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion)
 "en" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/excursion_dock)
 "eo" = (
@@ -1945,10 +1945,10 @@
 /area/shuttle/excursion)
 "ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/excursion_dock)
@@ -2213,7 +2213,7 @@
 /turf/simulated/floor/plating/snow/plating,
 /area/maintenance/auxsolarport)
 "fc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/excursion_dock)
 "fd" = (
@@ -2356,14 +2356,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/excursion_dock)
 "fu" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/table/steel,
 /obj/random/maintenance/engineering,
 /obj/random/maintenance/engineering,
 /obj/random/tech_supply,
 /obj/item/stack/cable_coil/random,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/cryogaia/station/excursion_dock)
 "fv" = (
@@ -2667,6 +2667,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "gi" = (
@@ -3065,9 +3068,6 @@
 /obj/item/weapon/reagent_containers/food/drinks/britcup,
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
@@ -5812,11 +5812,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/borealis2/outdoors/grounds/tower/northwest)
 "mw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/bed/chair/office/dark{
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
@@ -7499,7 +7499,7 @@
 /turf/simulated/floor/tiled,
 /area/cryogaia/station/hallway/primary/upper/south)
 "sK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -8035,13 +8035,13 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/belter)
 "vJ" = (
+/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
 "vK" = (
@@ -8850,6 +8850,9 @@
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "zT" = (
@@ -9087,9 +9090,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
@@ -9529,7 +9529,7 @@
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
 "Dx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
@@ -9868,10 +9868,10 @@
 	},
 /area/security/watchtower)
 "Fh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/bed/chair/office/dark,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled,
 /area/security/watchtower)
 "Fi" = (
@@ -10695,6 +10695,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/civilian/atrium/upper)
 "Kj" = (
@@ -10706,11 +10709,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Kk" = (
@@ -10941,7 +10946,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -11027,7 +11032,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -11095,9 +11100,6 @@
 /area/chapel/monastery/upper)
 "Mr" = (
 /obj/structure/dispenser/oxygen,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
@@ -13542,9 +13544,6 @@
 "ZT" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/landmark/start{
@@ -19979,7 +19978,7 @@ tX
 Xo
 Xo
 Xo
-Go
+tX
 Xo
 AM
 QB
@@ -20141,7 +20140,7 @@ tX
 za
 vO
 za
-Go
+tX
 Xo
 zC
 QB
@@ -20465,7 +20464,7 @@ Go
 za
 FL
 za
-tX
+Go
 Xo
 AM
 QB
@@ -20627,7 +20626,7 @@ Go
 Xo
 Xo
 Xo
-tX
+Go
 Xo
 AM
 QB
@@ -21222,7 +21221,7 @@ rh
 AE
 Dn
 YF
-Lk
+YF
 gh
 YF
 YF
@@ -21385,7 +21384,7 @@ UA
 YF
 Jz
 ZT
-YF
+Lk
 YF
 YF
 Dn


### PR DESCRIPTION
- Fixed countless issues with atmos piping.
- Fixed multiple issues with disposal piping
- A few additional AI holopads in head offices
- Moved the empty medkits in medical to a storage room, replaced with actual medkits.
- Moved that weird ash pile in engineering to a more appropriate location (in front of the emitter)
- Removed a duplicate APC, and a few redundant air controllers in xenoarch
- Additional emergency shutters in the toxins hallway
- A few extra tools to xenobotany (there wasn't even ONE complete set of tools)
- Two more lights, one in a hall, one in a maintenance tunnel near the elevator.
- Fixed a tree blocking the SM ejection... again
- Reinforced windows in xenobiology. Slime and Hazardous are now consistent.
- Fixed a few inconsistent floors
- Adjusted mail processing, infinite loop removed