### PR TITLE
Event Makers permissions test

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -219,18 +219,12 @@ var/global/floorIsLava = 0
 /datum/admins/proc/PlayerNotes()
 	set category = "Admin"
 	set name = "Player Notes"
-	if (!istype(src,/datum/admins))
-		src = usr.client.holder
-	if (!istype(src,/datum/admins))
-		to_chat(usr, "Error: you are not an admin!")
+	if (!check_rights(R_ADMIN|R_MOD)) //YW Edit, make sure you have admin or mod rights to mess with player notes
 		return
 	PlayerNotesPage(1)
 
 /datum/admins/proc/PlayerNotesFilter()
-	if (!istype(src,/datum/admins))
-		src = usr.client.holder
-	if (!istype(src,/datum/admins))
-		to_chat(usr, "Error: you are not an admin!")
+	if (!check_rights(R_ADMIN|R_MOD)) //YW Edit, make sure you have admin or mod rights to mess with player notes
 		return
 	var/filter = tgui_input_text(usr, "Filter string (case-insensitive regex)", "Player notes filter")
 	PlayerNotesPage(1, filter)
@@ -259,10 +253,7 @@ var/global/floorIsLava = 0
 /datum/admins/proc/show_player_info(var/key as text)
 	set category = "Admin"
 	set name = "Show Player Info"
-	if (!istype(src,/datum/admins))
-		src = usr.client.holder
-	if (!istype(src,/datum/admins))
-		to_chat(usr, "Error: you are not an admin!")
+	if (!check_rights(R_ADMIN|R_MOD)) //YW Edit, make sure you have admin or mod rights to mess with player notes
 		return
 
 	var/datum/tgui_module/player_notes_info/A = new(src)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -30,7 +30,7 @@
 		return
 
 	if(href_list["ahelp"])
-		if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
+		if(!check_rights(R_ADMIN|R_MOD|R_DEBUG)) // YW Edit: Remove ahelp viewing from event permissions
 			return
 
 		var/ahelp_ref = href_list["ahelp"]

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -628,7 +628,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set name = "Show Ticket List"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT, TRUE))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG, TRUE)) //YW Edit: Remove Ticket permissions from Event Makers
 		return
 
 	var/browse_to

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -35,7 +35,7 @@
 	if(check_rights(R_ADMIN, 0))
 		sender_name = "<span class='admin'>[sender_name]</span>"
 	for(var/client/C in GLOB.admins)
-		if(check_rights(R_ADMIN|R_MOD|R_SERVER)) //VOREStation Edit
+		if(check_rights(R_ADMIN|R_MOD|R_SERVER, 0, C)) //VOREStation Edit //YW Edit, fix issue with C missing from check_rights, so all admins could see mchat
 			to_chat(C, "<span class='mod_channel'>" + create_text_tag("mod", "MOD:", C) + " <span class='name'>[sender_name]</span>([admin_jump_link(mob, C.holder)]): <span class='message'>[msg]</span></span>")
 
 	feedback_add_details("admin_verb","MS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -639,7 +639,7 @@
 	set name = "Change Weather"
 	set desc = "Changes the current weather."
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_DEBUG|R_EVENT)) //YW Edit: Event Makers can change weather
 		return
 
 	var/datum/planet/planet = tgui_input_list(usr, "Which planet do you want to modify the weather on?", "Change Weather", SSplanets.planets)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -696,15 +696,16 @@
 					for(var/datum/controller/subsystem/SS in Master.subsystems)
 						SS.stat_entry()
 
-			if(statpanel("Tickets"))
-				GLOB.ahelp_tickets.stat_entry()
+			if(check_rights(R_ADMIN, 0))
+				if(statpanel("Tickets"))
+					GLOB.ahelp_tickets.stat_entry()
 
-
-			if(length(GLOB.sdql2_queries))
-				if(statpanel("SDQL2"))
-					stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
-					for(var/datum/SDQL2_query/Q as anything in GLOB.sdql2_queries)
-						Q.generate_stat()
+			if(check_rights(R_ADMIN|R_DEBUG, 0))
+				if(length(GLOB.sdql2_queries))
+					if(statpanel("SDQL2"))
+						stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
+						for(var/datum/SDQL2_query/Q as anything in GLOB.sdql2_queries)
+							Q.generate_stat()
 
 		if(has_mentor_powers(client))
 			if(statpanel("Tickets"))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -696,11 +696,11 @@
 					for(var/datum/controller/subsystem/SS in Master.subsystems)
 						SS.stat_entry()
 
-			if(check_rights(R_ADMIN, 0))
+			if(check_rights(R_ADMIN, 0)) //YW EDIT: Only admins can check Tickets
 				if(statpanel("Tickets"))
 					GLOB.ahelp_tickets.stat_entry()
 
-			if(check_rights(R_ADMIN|R_DEBUG, 0))
+			if(check_rights(R_ADMIN|R_DEBUG, 0)) //YW EDIT: Only admins/debug can access SDQL
 				if(length(GLOB.sdql2_queries))
 					if(statpanel("SDQL2"))
 						stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)


### PR DESCRIPTION
Totally untested code because testosterone.. Actually because testing would still end up on the same db so I'd have to make a new account.

Izac edit:
- [x] Allow EVENT to change the weather 
- [x] Only people with mod or Admin should be able to view and edit / add player notes
- [x] Only people with mod or Admin should be able to view and interact with tickets
- [x] Disallow non admins from viewing / interacting with asay 
- [x] Disallow non admins / mods from viewing / interacting with msay