### PR TITLE
Medalfluff and jungle vr map fix

### DIFF
--- a/code/modules/client/preference_setup/loadout/event_fluffitems_yw.dm
+++ b/code/modules/client/preference_setup/loadout/event_fluffitems_yw.dm
@@ -1,0 +1,13 @@
+/obj/item/clothing/accessory/medal/silver/achievement
+	name = "Medal of Achievement"
+	desc = "A silver medal awarded to corporate members who have achieved a corporate goal successfully."
+
+/obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	desc = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+
+/datum/gear/fluff/event_medal_twoshuttles
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("snakewitharocketlauncher", "blackangelsace", "bielbr12312332", "hidingdan", "montessquio", "tinncatt")
+	character_name = list("Dakula", "Art Echard", "Dustin Altmann", "Sierra Ellis", "Elise Maschenny", "Kurkivor Snowstrider")

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_yw.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_yw.dm
@@ -152,23 +152,6 @@
 	ckeywhitelist = list("blackangelsace")
 	character_name = list("Nicodemus Jarvis")
 
-//Art Echard
-/datum/gear/fluff/art_medal1
-	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	display_name = "Medal of Achievement"
-	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
-	ckeywhitelist = list("blackangelsace")
-    character_name = list("Art Echard")
-
-//Bielbr12312332
-//Dustin Altmann
-/datum/gear/fluff/dustin_medal1
-	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	display_name = "Medal of Achievement"
-	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
-	ckeywhitelist = list("bielbr12312332")
-    character_name = list("Dustin Altmann")
-
 //benl8561
 //M.I.S.S.Y
 /datum/gear/fluff/missy_skirt
@@ -594,15 +577,6 @@
 	character_name = list("Harpsong")
 	allowed_roles = list("Security Officer")
 
-//Hiding_Dan
-//Sierra Ellis
-/datum/gear/fluff/sierra_medal1
-	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	display_name = "Medal of Achievement"
-	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
-	ckeywhitelist = list("hidingdan")
-    character_name = list("Sierra Ellis")
-
 //  I CKEYS
 
 //izac112
@@ -845,15 +819,6 @@
     ckeywhitelist = list("mocatheporg1")
     character_name = list("Mocha")
 
-//Montessquio
-//Elise Maschenny
-/datum/gear/fluff/elise_medal1
-	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	display_name = "Medal of Achievement"
-	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
-	ckeywhitelist = list("montessquio")
-    character_name = list("Elise Maschenny")
-
 //  N CKEYS
 //NESgamer190
 /datum/gear/fluff/lucy_flask
@@ -973,14 +938,6 @@
 	ckeywhitelist = list("snakewitharocketlauncher")
 	character_name = list("Alex Wolf")
 
-//Dakula
-/datum/gear/fluff/dakula_medal1
-	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	display_name = "Medal of Achievement"
-	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
-	ckeywhitelist = list("snakewitharocketlauncher")
-    character_name = list("Dakula")
-
 //splintergp
 //Aroozee Daarvoleast-Clark
 /datum/gear/fluff/aroozee_cloak
@@ -1007,15 +964,6 @@
 
 
 //  T CKEYS
-
-//TinnCatt
-//Kurkivor Snowstrider
-/datum/gear/fluff/kurkivor_medal1
-	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	display_name = "Medal of Achievement"
-	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
-	ckeywhitelist = list("tinncatt")
-    character_name = list("Kurkivor Snowstrider")
 
 //  U CKEYS
 

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_yw.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_yw.dm
@@ -152,6 +152,23 @@
 	ckeywhitelist = list("blackangelsace")
 	character_name = list("Nicodemus Jarvis")
 
+//Art Echard
+/datum/gear/fluff/art_medal1
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("blackangelsace")
+    character_name = list("Art Echard")
+
+//Bielbr12312332
+//Dustin Altmann
+/datum/gear/fluff/dustin_medal1
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("bielbr12312332")
+    character_name = list("Dustin Altmann")
+
 //benl8561
 //M.I.S.S.Y
 /datum/gear/fluff/missy_skirt
@@ -577,6 +594,15 @@
 	character_name = list("Harpsong")
 	allowed_roles = list("Security Officer")
 
+//Hiding_Dan
+//Sierra Ellis
+/datum/gear/fluff/sierra_medal1
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("hidingdan")
+    character_name = list("Sierra Ellis")
+
 //  I CKEYS
 
 //izac112
@@ -819,6 +845,15 @@
     ckeywhitelist = list("mocatheporg1")
     character_name = list("Mocha")
 
+//Montessquio
+//Elise Maschenny
+/datum/gear/fluff/elise_medal1
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("montessquio")
+    character_name = list("Elise Maschenny")
+
 //  N CKEYS
 //NESgamer190
 /datum/gear/fluff/lucy_flask
@@ -938,6 +973,14 @@
 	ckeywhitelist = list("snakewitharocketlauncher")
 	character_name = list("Alex Wolf")
 
+//Dakula
+/datum/gear/fluff/dakula_medal1
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("snakewitharocketlauncher")
+    character_name = list("Dakula")
+
 //splintergp
 //Aroozee Daarvoleast-Clark
 /datum/gear/fluff/aroozee_cloak
@@ -964,6 +1007,15 @@
 
 
 //  T CKEYS
+
+//TinnCatt
+//Kurkivor Snowstrider
+/datum/gear/fluff/kurkivor_medal1
+	path = /obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	display_name = "Medal of Achievement"
+	description = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."
+	ckeywhitelist = list("tinncatt")
+    character_name = list("Kurkivor Snowstrider")
 
 //  U CKEYS
 

--- a/code/modules/clothing/under/accessories/accessory_yw.dm
+++ b/code/modules/clothing/under/accessories/accessory_yw.dm
@@ -12,3 +12,10 @@
 
 /obj/item/clothing/accessory/poncho/cloak/fluff/dropped() //makes the fluff cloaks not kek when used by a teshari
 	icon_override = 'icons/vore/custom_onmob_yw.dmi'
+
+/obj/item/clothing/accessory/medal/silver/achievement
+	name = "Medal of Achievement"
+	desc = "A silver medal awarded to corporate members who have achieved a corporate goal successfully."
+
+/obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
+	desc = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."

--- a/code/modules/clothing/under/accessories/accessory_yw.dm
+++ b/code/modules/clothing/under/accessories/accessory_yw.dm
@@ -12,10 +12,3 @@
 
 /obj/item/clothing/accessory/poncho/cloak/fluff/dropped() //makes the fluff cloaks not kek when used by a teshari
 	icon_override = 'icons/vore/custom_onmob_yw.dmi'
-
-/obj/item/clothing/accessory/medal/silver/achievement
-	name = "Medal of Achievement"
-	desc = "A silver medal awarded to corporate members who have achieved a corporate goal successfully."
-
-/obj/item/clothing/accessory/medal/silver/achievement/twoshuttlesevent
-	desc = "A silver medal awarded to corporate members who have achieved a corporate goal successfully. - This one was awarded for bringing two damaged shuttles back to Cryogaia for rescue and salvage."

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1997,6 +1997,7 @@
 #include "code\modules\client\preference_setup\global\03_pai.dm"
 #include "code\modules\client\preference_setup\global\04_ooc.dm"
 #include "code\modules\client\preference_setup\global\setting_datums.dm"
+#include "code\modules\client\preference_setup\loadout\event_fluffitems_yw.dm"
 #include "code\modules\client\preference_setup\loadout\gear_tweaks.dm"
 #include "code\modules\client\preference_setup\loadout\gear_tweaks_vr.dm"
 #include "code\modules\client\preference_setup\loadout\loadout.dm"


### PR DESCRIPTION
Adds event completion fluff item medals for 6 crew, Dakula, Kurkivor, Elise, Sierra, Art and Dustin

Also mistakes were made, but adds grills to jungle VR map and makes tunnellers appear less often due to how annoying they were.