### PR TITLE
shadekin Artifical bluespace crystals, fixes holo dorm flags

### DIFF
--- a/code/game/area/Space Station 13 areas_yw.dm
+++ b/code/game/area/Space Station 13 areas_yw.dm
@@ -192,7 +192,7 @@
 /area/security/outpost
 	name = "\improper Security outpost"
 	icon_state = "security"
-	flags = RAD_SHIELDED
+	flags = RAD_SHIELDED | PHASE_SHIELDED
 
 /area/security/labor
 	name = "Labor camp access"

--- a/maps/yw/cryogaia-04-maintenance.dmm
+++ b/maps/yw/cryogaia-04-maintenance.dmm
@@ -38363,6 +38363,9 @@
 /obj/item/weapon/stock_parts/subspace/crystal,
 /obj/item/weapon/stock_parts/subspace/crystal,
 /obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/bluespace_crystal/artificial,
+/obj/item/weapon/bluespace_crystal/artificial,
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor,
 /area/tcomstorage)
 "uTI" = (

--- a/maps/yw/cryogaia-05-main.dmm
+++ b/maps/yw/cryogaia-05-main.dmm
@@ -3962,6 +3962,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "bDs" = (
@@ -16042,6 +16043,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "geG" = (
@@ -16953,6 +16955,8 @@
 	name = "colony director's snow boots"
 	},
 /obj/item/clothing/glasses/omnihud/all,
+/obj/item/weapon/bluespace_crystal/artificial,
+/obj/item/weapon/paper/dockingcodes,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "gvD" = (
@@ -23748,7 +23752,6 @@
 	pixel_y = 9
 	},
 /obj/item/device/megaphone,
-/obj/item/weapon/paper/monitorkey,
 /obj/effect/floor_decal/corner_oldtile/purple/diagonal{
 	dir = 4
 	},
@@ -29388,6 +29391,7 @@
 	pixel_x = 30;
 	pixel_y = 30
 	},
+/obj/item/weapon/paper/monitorkey,
 /turf/simulated/floor/tiled/white,
 /area/rnd/rdoffice)
 "lss" = (
@@ -30270,6 +30274,7 @@
 /obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/industrial/outline,
 /obj/item/clothing/shoes/boots/jackboots/toeless,
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "lJO" = (
@@ -40013,6 +40018,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "pjn" = (
@@ -42717,6 +42723,7 @@
 "qkW" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "qkX" = (
@@ -58633,7 +58640,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/item/weapon/paper/dockingcodes,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "wAX" = (
@@ -60608,6 +60614,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/item/weapon/bluespace_crystal/artificial,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "xoA" = (

--- a/maps/yw/cryogaia_areas.dm
+++ b/maps/yw/cryogaia_areas.dm
@@ -269,28 +269,28 @@
 /area/crew_quarters/sleep/Dorm_1/holo
 	name = "\improper Dorm 1 Holodeck"
 	icon_state = "dk_yellow"
-	flags = RAD_SHIELDED | BLUE_SHIELDED
+	flags = RAD_SHIELDED | BLUE_SHIELDED | TEMPERATURE_SHIELDED | PHASE_SHIELDED
 	limit_mob_size = FALSE
 	block_suit_sensors = FALSE
 
 /area/crew_quarters/sleep/Dorm_3/holo
 	name = "\improper Dorm 3 Holodeck"
 	icon_state = "dk_yellow"
-	flags = RAD_SHIELDED | BLUE_SHIELDED
+	flags = RAD_SHIELDED | BLUE_SHIELDED | TEMPERATURE_SHIELDED | PHASE_SHIELDED
 	limit_mob_size = FALSE
 	block_suit_sensors = FALSE
 
 /area/crew_quarters/sleep/Dorm_5/holo
 	name = "\improper Dorm 5 Holodeck"
 	icon_state = "dk_yellow"
-	flags = RAD_SHIELDED | BLUE_SHIELDED
+	flags = RAD_SHIELDED | BLUE_SHIELDED | TEMPERATURE_SHIELDED | PHASE_SHIELDED
 	limit_mob_size = FALSE
 	block_suit_sensors = FALSE
 
 /area/crew_quarters/sleep/Dorm_7/holo
 	name = "\improper Dorm 7 Holodeck"
 	icon_state = "dk_yellow"
-	flags = RAD_SHIELDED | BLUE_SHIELDED
+	flags = RAD_SHIELDED | BLUE_SHIELDED | TEMPERATURE_SHIELDED | PHASE_SHIELDED
 	limit_mob_size = FALSE
 	block_suit_sensors = FALSE
 


### PR DESCRIPTION
Puts an artificial bluespace crystal in every sec officers locker and fixes the phase shielding for the holo dorm.